### PR TITLE
socket server와 연동 및 타이머 수정

### DIFF
--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -204,11 +204,9 @@ const MafiaPlay = () => {
       }
     });
 
-    //NOTE - "setReady"에서 모든 user가 Ready를 하면 "r0NightStart" 이 실행되며 게임이 시작된다.
     socket.on("r0NightStart", async (title, message, timer, nickname, yesOrNo) => {
       console.log("r0NightStart 수신");
 
-      // 타이머를 작동
       waitForMs(timer);
       console.log(`${timer}ms 뒤에 ${message} 모달 창 띄움`);
 

--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -204,12 +204,15 @@ const MafiaPlay = () => {
       }
     });
 
+    //NOTE - "setReady"에서 모든 user가 Ready를 하면 "r0NightStart" 이 실행되며 게임이 시작된다.
     socket.on("r0NightStart", async (title, message, timer, nickname, yesOrNo) => {
       console.log("r0NightStart 수신");
 
+      // 타이머를 작동
       waitForMs(timer);
       console.log(`${timer}ms 뒤에 ${message} 모달 창 띄움`);
 
+      // 타이머를 붙잡기 위한 용도
       await setStatus(userId.current, { r0NightStart: true });
       socket.emit("r0NightStart", roomId.current);
       console.log("r0NightStart 송신");

--- a/app/(withGlobalLayout)/main/page.tsx
+++ b/app/(withGlobalLayout)/main/page.tsx
@@ -1,26 +1,26 @@
 "use client";
 import PeopleIcon from "@/assets/images/icon_person.svg";
+import SearchIcon from "@/assets/images/icon_search.svg";
 import MafiaGameTitle from "@/assets/images/mafia_game_title.svg";
 import MafiaItem from "@/assets/images/mafia_item.png";
+import VisitEmptyImage from "@/assets/images/visit_empty.svg";
 import useConnectStore from "@/store/connect-store";
 import S from "@/style/mainPage/main.module.css";
 import { Tables } from "@/types/supabase";
+import GoTopButton from "@/utils/GoTopButton";
 import { socket } from "@/utils/socket/socket";
 import { checkUserLogIn, getUserInfo } from "@/utils/supabase/authAPI";
+import { getRoomsWithKeyword } from "@/utils/supabase/roomAPI";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import MainCreateRoom from "../../../components/mainpageComponents/MainCreateRoom";
-import { useModalStore } from "../../../store/toggle-store";
-import GoTopButton from "@/utils/GoTopButton";
-import VisitEmptyImage from "@/assets/images/visit_empty.svg";
-import { getRoomsWithKeyword } from "@/utils/supabase/roomAPI";
-import Link from "next/link";
-import SearchIcon from "@/assets/images/icon_search.svg";
+import { useCreateStore } from "../../../store/toggle-store";
 
 const Mainpage = () => {
-  const { isModal, setIsModal } = useModalStore();
+  const { isCreate, setIsCreate } = useCreateStore();
   const { userId, nickname, setRoomId, setUserId, setUserNickname } = useConnectStore();
   const [rooms, setRooms] = useState([] as Tables<"room_table">[]);
   const [search, setSearch] = useState("");
@@ -202,11 +202,11 @@ const Mainpage = () => {
                   빠른입장
                 </button>
                 <div className={S.makeRoomButton}>
-                  <button onClick={() => setIsModal(true)} className={S.makeRoom}>
+                  <button onClick={() => setIsCreate(true)} className={S.makeRoom}>
                     방 만들기
                   </button>
                 </div>
-                {isModal ? <MainCreateRoom /> : null}
+                {isCreate ? <MainCreateRoom /> : null}
               </div>
             </div>
           </div>

--- a/components/mafia/CheckModal.tsx
+++ b/components/mafia/CheckModal.tsx
@@ -4,9 +4,13 @@ import { useCountDown } from "@/hooks/useCountDown";
 import { socket } from "@/utils/socket/socket";
 import useConnectStore from "@/store/connect-store";
 import { VoteData } from "@/types";
+import useShowModalStore from "@/store/showModal.store";
 
 const CheckModal = () => {
+  // const { timer } = useShowModalStore();
+  // const initialSecond = timer;
   const initialSecond = 5;
+
   const count = useCountDown(initialSecond);
   const { userId } = useConnectStore();
   //NOTE - 찬반 투표 대상이 되는 다른 사용자의 ID와 닉네임을 저장하는 state

--- a/components/mafia/GroupMafiaModal.tsx
+++ b/components/mafia/GroupMafiaModal.tsx
@@ -1,28 +1,34 @@
 import { useCountDown } from "@/hooks/useCountDown";
 import useModal from "@/hooks/useModal";
+import useShowModalStore from "@/store/showModal.store";
 import S from "@/style/modal/modal.module.css";
 
 const GroupMafiaModal = () => {
-  const initialSecond = 5;
-  const count = useCountDown(initialSecond);
+  const { setIsClose, isOpen, timer, title, message } = useShowModalStore();
+  const count = useCountDown(timer);
   const { modalState } = useModal();
 
-  //NOTE - 모달이 열리지 않았을 때 아무것도 랜더링 하지 않아야 함
-  if (!modalState.isOpen) return null;
+  // 초기값인 0으로 인해 progress bar 게이지가 100% 상태가 유지되는 현상이 발생하므로
+  // timer에 값이 들어가기 전 0값에 대한 처리문
+  // useCountDown에서 초기값 0에 대한 처리문을 진행하면 더 깔끔하다.
+  if (count === 0) {
+    return null;
+  }
+
+  console.log((timer * 10 - count) * (100 / (timer * 10)));
+
+  // //NOTE - 모달이 열리지 않았을 때 아무것도 랜더링 하지 않아야 함
+  if (!isOpen) return null;
 
   return (
     <>
       <div className={S.modalWrap}>
         <div className={S.modal}>
           <div>
-            {modalState.title && <h1>{modalState.title}</h1>}
+            {title && <h1>{title}</h1>}
             {modalState.message && <h2>{modalState.message}</h2>}
             {modalState.nickname && <h2>{modalState.nickname}</h2>}
-            <progress
-              className={S.progress}
-              value={(initialSecond * 10 - count) * (100 / (initialSecond * 10))}
-              max={100}
-            ></progress>
+            <progress className={S.progress} value={(timer * 10 - count) * (100 / (timer * 10))} max={100}></progress>
           </div>
         </div>
       </div>

--- a/components/mafia/JoinMafiaRoom.tsx
+++ b/components/mafia/JoinMafiaRoom.tsx
@@ -26,6 +26,7 @@ const JoinMafiaRoom = () => {
   if (isError) {
     console.log("토큰 발급중 에러 발생");
   }
+  console.log("token", token);
 
   //NOTE - 방을 나갈 시에 작동되는 이벤트 헨들러 ==> useEffect와 비슷하다.
   const disConnected = () => {

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -1,7 +1,7 @@
 import CamCheck from "@/assets/images/cam_check.svg";
 import useConnectStore from "@/store/connect-store";
 import useOverlayStore from "@/store/overlay-store";
-import { useModalStore } from "@/store/toggle-store";
+import { useModalStore, useReadyStore } from "@/store/toggle-store";
 import S from "@/style/livekit/livekit.module.css";
 import { Participants } from "@/types";
 import { socket } from "@/utils/socket/socket";
@@ -15,7 +15,7 @@ const LocalParticipant: React.FC<Participants> = ({ tracks, checkClickHandle }) 
   const { activeParticipantSid, isLocalOverlay } = useOverlayStore();
   const { roomId, userId } = useConnectStore();
   const { isModal, setIsModal } = useModalStore();
-  const [isReady, setIsReady] = useState(false);
+  const { isReady, setIsReady } = useReadyStore();
   const [modalMessage, setModalMessage] = useState("");
 
   const localTracks = tracks.filter((track) => track.participant.sid === localParticipant.sid)!;
@@ -30,6 +30,7 @@ const LocalParticipant: React.FC<Participants> = ({ tracks, checkClickHandle }) 
   useEffect(() => {
     socket.on("setReady", (message) => {
       console.log("게임 준비", message);
+
       setModalMessage(message);
       setIsModal(true);
     });

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -9,6 +9,7 @@ import { ParticipantTile, useLocalParticipant } from "@livekit/components-react"
 import Image from "next/image";
 import React, { useEffect, useState } from "react";
 import GroupMafiaModal from "./GroupMafiaModal";
+import useShowModalStore from "@/store/showModal.store";
 
 const LocalParticipant: React.FC<Participants> = ({ tracks, checkClickHandle }) => {
   const { localParticipant } = useLocalParticipant();
@@ -17,6 +18,7 @@ const LocalParticipant: React.FC<Participants> = ({ tracks, checkClickHandle }) 
   const { isModal, setIsModal } = useModalStore();
   const { isReady, setIsReady } = useReadyStore();
   const [modalMessage, setModalMessage] = useState("");
+  const { isOpen } = useShowModalStore();
 
   const localTracks = tracks.filter((track) => track.participant.sid === localParticipant.sid)!;
 
@@ -59,7 +61,7 @@ const LocalParticipant: React.FC<Participants> = ({ tracks, checkClickHandle }) 
       <button style={{ backgroundColor: isReady ? "#5c5bad" : "#bfbfbf" }} onClick={startGameHandler}>
         {isReady ? "취소" : "게임 준비"}
       </button>
-      {isModal && <GroupMafiaModal />}
+      {isOpen && <GroupMafiaModal />}
     </div>
   );
 };

--- a/components/mafia/MafiaPlayRooms.tsx
+++ b/components/mafia/MafiaPlayRooms.tsx
@@ -160,7 +160,7 @@ const MafiaPlayRooms = () => {
       socket.off("r0TurnMafiaUserCameraOff");
       socket.off("r1MorningStart");
     };
-  }, []);
+  }, [tracks]);
 
   //NOTE - 게임 시작
   const socketGameStart = () => {

--- a/components/mainpageComponents/MainCreateRoom.tsx
+++ b/components/mainpageComponents/MainCreateRoom.tsx
@@ -1,7 +1,7 @@
 import MafiaGameChoiceActive from "@/assets/images/game_choice_mafia_active.svg";
 import MafiaGameSong from "@/assets/images/game_choice_song.svg";
 import useConnectStore from "@/store/connect-store";
-import { useModalStore } from "@/store/toggle-store";
+import { useCreateStore } from "@/store/toggle-store";
 import S from "@/style/modal/modal.module.css";
 import { socket } from "@/utils/socket/socket";
 import { checkUserLogIn } from "@/utils/supabase/authAPI";
@@ -16,7 +16,7 @@ const MainCreateRoom = () => {
   const [numberOfPlayers, setNumberOfPlayers] = useState(5);
   const isGoInClick = useRef(false);
   const roomId = useRef("");
-  const { setIsModal } = useModalStore();
+  const { setIsCreate } = useCreateStore();
   const { userId, nickname, setRoomId } = useConnectStore();
   const router = useRouter();
 
@@ -34,7 +34,7 @@ const MainCreateRoom = () => {
     socket.on("joinRoom", () => {
       if (roomId.current) {
         setRoomId(roomId.current);
-        setIsModal(false);
+        setIsCreate(false);
         router.push(`/room/${roomId.current}/`);
       }
     });
@@ -54,7 +54,7 @@ const MainCreateRoom = () => {
 
   const closeModalHandler = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (e.target === e.currentTarget) {
-      setIsModal(false);
+      setIsCreate(false);
     }
   };
 
@@ -124,7 +124,7 @@ const MainCreateRoom = () => {
             </select>
           </div>
           <div className={S.gameChoiceButton}>
-            <button className={S.closedButton} onClick={() => setIsModal(false)}>
+            <button className={S.closedButton} type="button" onClick={() => setIsCreate(false)}>
               닫기
             </button>
             <button disabled={isGoInClick.current} type="submit">

--- a/hooks/useCountDown.ts
+++ b/hooks/useCountDown.ts
@@ -1,25 +1,31 @@
+import useShowModalStore from "@/store/showModal.store";
 import { useEffect, useState } from "react";
-import { useModalStore } from "../store/toggle-store";
 
 export const useCountDown = (initialSecond: number) => {
-  const { isModal, setIsModal } = useModalStore();
   const [count, setCount] = useState(initialSecond * 10);
+  const { setIsClose, setIsOpen } = useShowModalStore();
 
   useEffect(() => {
     let timer = initialSecond * 10;
-    const intervalId = setInterval(() => {
-      timer--;
-      setCount((prev) => prev - 1);
 
-      if (timer === -1) {
-        setIsModal(false);
+    const intervalId = setInterval(() => {
+      if (timer === 0) {
+        setIsClose(true);
+        setIsOpen(false);
         setCount(0);
         clearInterval(intervalId);
+      } else {
+        timer--;
+        setCount((prev) => prev - 1);
+      }
+
+      if (timer <= 0) {
+        return;
       }
     }, 100);
 
     return () => clearInterval(intervalId);
-  }, [isModal, initialSecond]);
+  }, []);
 
   return count;
 };

--- a/hooks/useCountUp.ts
+++ b/hooks/useCountUp.ts
@@ -1,22 +1,22 @@
-import { useEffect } from "react";
-import { useCountStore } from "../store/count-store";
+// import { useEffect } from "react";
+// import { useCountStore } from "../store/count-store";
 
-const useCountUp = (): number => {
-  const { timer, setTimer, isStart } = useCountStore();
+// const useCountUp = (): number => {
+//   const { timer, setTimer, isStart } = useCountStore();
 
-  useEffect(() => {
-    let intervalId: any;
+//   useEffect(() => {
+//     let intervalId: any;
 
-    if (isStart) {
-      intervalId = setInterval(() => {
-        setTimer(timer + 1);
-      }, 1000);
-    }
+//     if (isStart) {
+//       intervalId = setInterval(() => {
+//         setTimer(timer + 1);
+//       }, 1000);
+//     }
 
-    return () => clearInterval(intervalId);
-  }, [isStart, timer]);
+//     return () => clearInterval(intervalId);
+//   }, [isStart, timer]);
 
-  return timer;
-};
+//   return timer;
+// };
 
-export default useCountUp;
+// export default useCountUp;

--- a/store/showModal.store.ts
+++ b/store/showModal.store.ts
@@ -1,0 +1,19 @@
+import { ShowModalState } from "@/types";
+import { create } from "zustand";
+
+//NOTE - 모달의 데이터 요소
+const useShowModalStore = create<ShowModalState>((set) => ({
+  isOpen: false,
+  title: "",
+  message: "",
+  nickname: "",
+  timer: 0,
+  isClose: false,
+  setIsOpen: (newIsOpen) => set({ isOpen: newIsOpen }),
+  setTitle: (newTitle) => set({ title: newTitle }),
+  setMessage: (newMessage) => set({ message: newMessage }),
+  setTimer: (newTimer) => set({ timer: newTimer }),
+  setIsClose: (newIsClose) => set({ isClose: newIsClose })
+}));
+
+export default useShowModalStore;

--- a/store/toggle-store.ts
+++ b/store/toggle-store.ts
@@ -1,8 +1,14 @@
 import { create } from "zustand";
-import { ModalState } from "../types";
+import { ModalState, ReadyState } from "../types";
 
 export const useModalStore = create<ModalState>((set) => ({
   isModal: false,
 
   setIsModal: (newToggle: boolean) => set({ isModal: newToggle })
+}));
+
+export const useReadyStore = create<ReadyState>((set) => ({
+  isReady: false,
+
+  setIsReady: (newToggle: boolean) => set({ isReady: newToggle })
 }));

--- a/store/toggle-store.ts
+++ b/store/toggle-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { ModalState, ReadyState } from "../types";
+import { CreateState, ModalState, ReadyState } from "../types";
 
 export const useModalStore = create<ModalState>((set) => ({
   isModal: false,
@@ -11,4 +11,10 @@ export const useReadyStore = create<ReadyState>((set) => ({
   isReady: false,
 
   setIsReady: (newToggle: boolean) => set({ isReady: newToggle })
+}));
+
+export const useCreateStore = create<CreateState>((set) => ({
+  isCreate: false,
+
+  setIsCreate: (newToggle: boolean) => set({ isCreate: newToggle })
 }));

--- a/types/index.ts
+++ b/types/index.ts
@@ -125,3 +125,8 @@ export interface ReadyState {
   isReady: boolean;
   setIsReady: (newReady: boolean) => void;
 }
+
+export interface CreateState {
+  isCreate: boolean;
+  setIsCreate: (newReady: boolean) => void;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -130,3 +130,17 @@ export interface CreateState {
   isCreate: boolean;
   setIsCreate: (newReady: boolean) => void;
 }
+
+export interface ShowModalState {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  nickname?: string;
+  timer: number;
+  isClose: boolean;
+  setIsOpen: (newIsOpen: boolean) => void;
+  setTitle: (newTitle: string) => void;
+  setMessage: (newMessage: string) => void;
+  setTimer: (newTimer: number) => void;
+  setIsClose: (newIsClose: boolean) => void;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -120,3 +120,8 @@ export interface ExitState {
   isExit: boolean;
   setIsExit: (newToggle: boolean) => void;
 }
+
+export interface ReadyState {
+  isReady: boolean;
+  setIsReady: (newReady: boolean) => void;
+}


### PR DESCRIPTION
## 📌 관련 이슈
  closed #196 

## Task TODOLIST
- [x] server socket 연동
- [x] 타이머 기능 수정

## ✨ 개발 내용
```tsx
useEffect(() => {
    //NOTE - 게임 시작
    socket.on("r0NightStart", async (title, message, timer) => {
      //NOTE - 모달창 띄우기
      console.log("r0NightStart 수신");
      setIsOpen(true);
      setTitle("게임이 시작됩니다.");
      setMessage("다들 즐길 준비 되셨나요? 그러면 출발~~");
      setTimer(5);
      setIsOverlay(false); //클릭 이벤트 비활성화

      // 5초 후에 setStatus와 socket.emit 실행
      const r0NightStartTimer = setTimeout(async () => {
        await setStatus(userId, { r0NightStart: true });
        socket.emit("r0NightStart", roomId);
        console.log("r0NightStart 송신");
      }, 5000);

      // 생성된 타이머 ID를 저장
      setTimerIds((prevTimerIds) => [...prevTimerIds, r0NightStartTimer]);
    }); return () => {
      // 저장된 모든 타이머 클리어
      timerIds.forEach((timerId) => {
        console.log("timerId", timerId);
        clearTimeout(timerId);
      });
      socket.off("r0NightStart");
      socket.off("r0TurnAllUserCameraMikeOff");
      socket.off("r0SetAllUserRole");
      socket.off("r0ShowAllUserRole");
      socket.off("r0ShowMafiaUserEachOther");
      socket.off("r0TurnMafiaUserCameraOn");
      socket.off("r0TurnMafiaUserCameraOff");
      socket.off("r1MorningStart");
    };
  }, [tracks]);

```
##  TroubleShotting
모달창에 띄우는 progress bar의 게이지가 100%으로 시작되는 현상이 발생하여 게이지가 차오르는 효과 x

1. 해당 부분의 timer와 count의 값을 console로 확인
2.  value={(timer * 10 - count) * (100 / (timer * 10))}에 값의 변화를 확인
value값을 확인해본 결과 게이지의 시작이 100이라는 값이 찍히는 걸 확인하였다. 
해결방법) 초기값인 0으로 인해 계산 결과값이 100이였으며, 조건문을 통해 초기값에 대한 처리를 하여 정상작동하게 만듦
```html
<progress className={S.progress} value={(timer * 10 - count) * (100 / (timer * 10))} max={100}></progress>

```
