### PR TITLE
[Fix #201] - 서버 및 클라이언트 게임 로직 수정

### DIFF
--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -204,6 +204,10 @@ const MafiaPlay = () => {
       }
     });
 
+    socket.on("updateUserReady", (userId, ready) => {
+      console.log(`${userId}가 ready를 ${ready} 함`);
+    });
+
     socket.on("r0NightStart", async (title, message, timer, nickname, yesOrNo) => {
       console.log("r0NightStart 수신");
 

--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -131,8 +131,8 @@ const MafiaPlay = () => {
       console.log(message);
     });
 
-    socket.on("exitRoom", (userInfo) => {
-      console.log(userInfo);
+    socket.on("exitRoom", () => {
+      console.log("방에서 나갔습니다.");
     });
 
     socket.on("exitRoomError", (message) => {
@@ -407,6 +407,7 @@ const MafiaPlay = () => {
         } else {
           console.log("무효 투표라서 아무도 죽지 않음");
         }
+        console.log("만약 killedPlayer가 자신이라면 죽었다고 관전할거냐면서 물어보고 방에서 나갈지 사망할지 처리.");
 
         await setStatus(userId.current, { r1KillMostVotedPlayer: true });
         socket.emit("r1KillMostVotedPlayer", roomId.current);
@@ -465,12 +466,15 @@ const MafiaPlay = () => {
       console.log("r1TurnMafiaUserCameraOff 송신");
     });
 
-    socket.on("r1DecideDoctorToSavePlayer", async (title, message, timer, nickname, yesOrNo) => {
+    socket.on("r1DecideDoctorToSavePlayer", async (title, message, timer, nickname, yesOrNo, isValid, doctorPlayer) => {
       console.log("r1DecideDoctorToSavePlayer 수신");
       const player = null;
       waitForMs(timer);
       console.log(`${timer}ms 뒤에 ${message} 모달 창 띄움`);
-      console.log("message가 의사가 있다는 메세지이면 userId 넣어서 송신, 없으면 null 넣어서 송신");
+      console.log();
+      console.log(
+        "valid : 방 구성인원에 의사가 있음, doctorPlayer :  의사가 살아있으면 유저 아이디 죽었으면 null, player :  살릴 플레이어 유저아이디 대입"
+      );
 
       await setStatus(userId.current, { r1DecideDoctorToSavePlayer: true });
       socket.emit("r1DecideDoctorToSavePlayer", roomId.current, player);
@@ -482,7 +486,9 @@ const MafiaPlay = () => {
       const player = null;
       waitForMs(timer);
       console.log(`${timer}ms 뒤에 ${message} 모달 창 띄움`);
-      console.log("message가 경찰이 있다는 메세지이면 userId 넣어서 송신, 없으면 null 넣어서 송신");
+      console.log(
+        "valid : 방 구성인원에 경찰이 있음, policePlayer :  의사가 살아있으면 유저 아이디 죽었으면 null, player :  의심하는 플레이어 유저아이디 대입"
+      );
 
       await setStatus(userId.current, { r1DecidePoliceToDoubtPlayer: true });
       socket.emit("r1DecidePoliceToDoubtPlayer", roomId.current, player);

--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -395,17 +395,24 @@ const MafiaPlay = () => {
       console.log("r1ShowVoteYesOrNoResult 송신");
     });
 
-    socket.on("r1KillMostVotedPlayer", async (title, message, timer, nickname, yesOrNo, killedPlayer, role) => {
-      console.log("r1KillMostVotedPlayer 수신");
+    socket.on(
+      "r1KillMostVotedPlayer",
+      async (title, message, timer, nickname, yesOrNo, isValid, killedPlayer, role) => {
+        console.log("r1KillMostVotedPlayer 수신");
 
-      waitForMs(timer);
-      console.log(`${timer}ms 뒤에 ${message} 모달 창 띄움`);
-      console.log(`${killedPlayer}가 ${role}인거 밝힘`);
+        waitForMs(timer);
+        console.log(`${timer}ms 뒤에 ${message} 모달 창 띄움`);
+        if (isValid) {
+          console.log(`${killedPlayer}가 ${role}인거 밝힘`);
+        } else {
+          console.log("무효 투표라서 아무도 죽지 않음");
+        }
 
-      await setStatus(userId.current, { r1KillMostVotedPlayer: true });
-      socket.emit("r1KillMostVotedPlayer", roomId.current);
-      console.log("r1KillMostVotedPlayer 송신");
-    });
+        await setStatus(userId.current, { r1KillMostVotedPlayer: true });
+        socket.emit("r1KillMostVotedPlayer", roomId.current);
+        console.log("r1KillMostVotedPlayer 송신");
+      }
+    );
 
     socket.on("r1TurnAllUserCameraMikeOff", async (allPlayers) => {
       console.log("r1TurnAllUserCameraMikeOff 수신");

--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -551,15 +551,13 @@ const MafiaPlay = () => {
       console.log("r2AskPlayerToExit 송신");
     });
 
-    socket.on("r2WhoWIns", async (title, message, timer, nickname, yesOrNo) => {
-      console.log("r2WhoWIns 수신");
+    socket.on("gameOver", async (title, message, timer, nickname, yesOrNo) => {
+      console.log("gameOver 수신");
 
       waitForMs(timer);
       console.log(`${timer}ms 뒤에 ${message} 모달 창 띄움`);
-
-      socket.emit("r2WhoWIns", roomId.current);
-      console.log("r2WhoWIns 송신");
     });
+
     socket.on("updateUserInRoom", (playerInfo) => {
       console.log("updateUserInRoom 수신");
       console.log(`GUI에 표시할 정보들 : ${playerInfo}`);

--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -242,7 +242,10 @@ const MafiaPlay = () => {
     socket.on("r0ShowAllUserRole", async (role) => {
       console.log("r0ShowAllUserRole 수신");
 
-      console.log(`역할들 : ${role}`);
+      console.log(`마피아 : ${role["마피아"]}`);
+      console.log(`의사 : ${role["의사"]}`);
+      console.log(`경찰 : ${role["경찰"]}`);
+      console.log(`시민 : ${role["시민"]}`);
 
       await setStatus(userId.current, { r0ShowAllUserRole: true });
       socket.emit("r0ShowAllUserRole", roomId.current);
@@ -349,14 +352,13 @@ const MafiaPlay = () => {
       console.log("r1ShowVoteToResult 송신");
     });
 
-    socket.on("r1ShowMostVotedPlayer", async (title, message, timer, nickname, yesOrNo) => {
+    socket.on("r1ShowMostVotedPlayer", async (title, message, timer, nickname, yesOrNo, isValid) => {
       console.log("r1ShowMostVotedPlayer 수신");
-
       waitForMs(timer);
       console.log(`${timer}ms 뒤에 ${message} 모달 창 띄움`);
-
       await setStatus(userId.current, { r1ShowMostVotedPlayer: true });
-      socket.emit("r1ShowMostVotedPlayer", roomId.current);
+
+      socket.emit("r1ShowMostVotedPlayer", roomId.current, isValid);
       console.log("r1ShowMostVotedPlayer 송신");
     });
 

--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -551,6 +551,10 @@ const MafiaPlay = () => {
       socket.emit("r2WhoWIns", roomId.current);
       console.log("r2WhoWIns 송신");
     });
+    socket.on("updateUserInRoom", (playerInfo) => {
+      console.log("updateUserInRoom 수신");
+      console.log(`GUI에 표시할 정보들 : ${playerInfo}`);
+    });
   }, []);
 
   return (


### PR DESCRIPTION
## 📌 관련 이슈
closed #201

## Task TODOLIST
- [X] 게임 로직 예외 경우 서버에 대처 코드 작성
- [X] 게임 로직 예외 경우 클라이언트에 대처 코드 작성
- [X] 유저의 여러 플레이 상황을 고려하여 서버에 코드 작성
- [X] 유저의 여러 플레이 상황을 고려하여 클라이언트에 코드 작성

## ✨ 개발 내용
게임 로직 예외 상황 대처

##  TroubleShotting
1. 게임 조건이 만족되는 경우 바로 클라이언트에게 알려야되는 경우가 있어서 게임 진행에 문제가 있었습니다.
- 이 문제는 서버가 수신하는 타이밍에 받아서 수정하는 수행하게 수정하였습니다.

2. 클라이언트가 게임 종료 버튼이 아닌 페이지를 이동하거나 브라우저를 정료하면서 연결이 끊긴 경우 게임 진행에 문제가 있었습니다.
- 이 문제는 socket.io의 공식 문서에서 socket이 끊기는 경우 발생하는 이벤트를 이용하여 해결하였습니다.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
[socket.io 공식 문서](https://socket.io/docs/v4/)
