### PR TITLE
원격 사용자의 카메라 기능 수정

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -1,6 +1,6 @@
 import { TrackReference, TrackReferenceOrPlaceholder } from "@livekit/components-react";
 import { User } from "@supabase/supabase-js";
-import { LocalParticipant, Participant, Track } from "livekit-client";
+import { LocalParticipant, Participant, RemoteParticipant, Track } from "livekit-client";
 import { StaticImageData } from "next/image";
 import { Dispatch, SetStateAction } from "react";
 
@@ -166,7 +166,8 @@ export interface ShowModalComponents {
 export interface MediaState {
   tracks: TrackReferenceOrPlaceholder[];
   localUserId: string | undefined;
-  specificUser: TrackReference[];
+  remoteParticipants: RemoteParticipant[];
+  players: [];
   userId: string;
   roomId: string;
   sources: Track.Source[];

--- a/types/index.ts
+++ b/types/index.ts
@@ -167,7 +167,7 @@ export interface MediaState {
   tracks: TrackReferenceOrPlaceholder[];
   localUserId: string | undefined;
   remoteParticipants: RemoteParticipant[];
-  players: [];
+  players: string[];
   userId: string;
   roomId: string;
   sources: Track.Source[];

--- a/utils/mafiaSocket/mafiaSocket.ts
+++ b/utils/mafiaSocket/mafiaSocket.ts
@@ -1,9 +1,10 @@
 import { MediaState, ShowModalComponents } from "@/types";
-import { TrackReferenceOrPlaceholder, useLocalParticipant, useParticipantTracks } from "@livekit/components-react";
+import { TrackReferenceOrPlaceholder } from "@livekit/components-react";
 import { allMediaSetting, specificUserVideoSetting } from "../participantCamSettings/camSetting";
 import { socket } from "../socket/socket";
 import { setStatus } from "../supabase/statusAPI";
 
+//NOTE - 게임 시작
 export const r0NightStartHandler = async ({
   roomId,
   userId,
@@ -16,12 +17,12 @@ export const r0NightStartHandler = async ({
 }: ShowModalComponents) => {
   console.log("r0NightStart 수신");
 
-  //NOTE - 모달창 요소
+  // 모달창 요소
   setIsOpen(true);
   setTitle("게임 시작");
   setMessage("누군가 당신의 뒤를 노리고 있습니다.");
   setTimer(5);
-  setIsOverlay(false); //클릭 이벤트 비활성화
+  setIsOverlay(false); //캠 클릭 이벤트 비활성화
 
   // 5초 후에 setStatus와 socket.emit 실행
   const r0NightStartTimer = setTimeout(async () => {
@@ -34,6 +35,7 @@ export const r0NightStartHandler = async ({
   setTimerIds((prevTimerIds) => [...prevTimerIds, r0NightStartTimer]);
 };
 
+//NOTE - 카메라 및 마이크 off
 export const r0TurnAllUserCameraMikeOffHandler = async (
   tracks: TrackReferenceOrPlaceholder[],
   userId: string,
@@ -49,6 +51,7 @@ export const r0TurnAllUserCameraMikeOffHandler = async (
   console.log("r0TurnAllUserCameraMikeOff 송신");
 };
 
+//NOTE - UI: 마피아 유저에게 "마피아들은 고개를 들어 서로를 확인해 주세요." 모달창 띄우기
 export const r0ShowMafiaUserEachOther = async ({
   roomId,
   userId,
@@ -61,12 +64,12 @@ export const r0ShowMafiaUserEachOther = async ({
 }: ShowModalComponents) => {
   console.log("r0ShowMafiaUserEachOther 수신");
 
-  //NOTE - 모달창 요소
+  //모달창 요소
   setIsOpen(true);
   setTitle("마피아 시간");
   setMessage("클클클... 누군가를 죽여야한다니 흥미롭군, 나의 파트너는 누구지?");
   setTimer(5);
-  setIsOverlay(false); //클릭 이벤트 비활성화
+  setIsOverlay(false); //캠 클릭 이벤트 비활성화
 
   // 5초 후에 setStatus와 socket.emit 실행
   const r0ShowMafiaUserEachOtherTimer = setTimeout(async () => {
@@ -79,31 +82,39 @@ export const r0ShowMafiaUserEachOther = async ({
   setTimerIds((prevTimerIds) => [...prevTimerIds, r0ShowMafiaUserEachOtherTimer]);
 };
 
-//NOTE -  마피아 유저 화상 카메라와 마이크만 켬
+//NOTE -  마피아 유저의 캠 및 오디오 ON
 export const r0TurnMafiaUserCameraOnHandler = async ({
   tracks,
   localUserId,
-  specificUser,
+  remoteParticipants,
+  players,
   userId,
   roomId,
   setTimerIds
 }: MediaState) => {
   console.log("r0TurnMafiaUserCameraOn 수신");
 
-  console.log("localUserId", localUserId);
-  console.log("specificUser", specificUser);
   allMediaSetting(tracks, false);
-  //NOTE -  1) 특정 유저의 track을 받아온다.
-  // specificUser
-  //NOTE -  2) 현재 방의 유저 중에 특정 user인지를 파악한다.
-  if (!localUserId || !specificUser) {
-    return;
+  // console.log("localUserId", localUserId);
+  // console.log("userId", userId);
+  // console.log("RemoteParticipants", RemoteParticipants);
+  // console.log("players", players);
+
+  // 1) localUserId, specificUser, players의 값이 null이 아닐 경우에만 수행
+  if (!localUserId || !remoteParticipants || !players) {
+    return () => {};
   }
 
-  if (localUserId === userId) {
-    //NOTE -  3) 해당 특정 유저일 경우 track 및 boolean값을 통해 캠 활성화 및 비활성화
-    specificUserVideoSetting(specificUser, true);
-  }
+  // 2) 특정 유저의 track 및 boolean값을 통해 캠 활성화
+  const MafiaUserId = players.map((userId) => {
+    return remoteParticipants.map((remote) => {
+      if (remote.metadata === userId && localUserId === userId) {
+        return remote;
+      }
+    });
+  });
+  console.log("MafiaUserId", MafiaUserId);
+  // specificUserVideoSetting(MafiaUserId, true)
 
   // 5초 후에 setStatus와 socket.emit 실행
   const r0TurnMafiaUserCameraOnTimer = setTimeout(async () => {
@@ -116,11 +127,12 @@ export const r0TurnMafiaUserCameraOnHandler = async ({
   setTimerIds((prevTimerIds: any) => [...prevTimerIds, r0TurnMafiaUserCameraOnTimer]);
 };
 
-//NOTE -  마피아 유저 화상 카메라와 마이크만 켬
+//NOTE -  마피아 유저의 캠 및 오디오 Off
 export const r0TurnMafiaUserCameraOffHandler = async ({
   tracks,
   localUserId,
-  specificUser,
+  remoteParticipants,
+  players,
   userId,
   roomId,
 
@@ -128,13 +140,20 @@ export const r0TurnMafiaUserCameraOffHandler = async ({
 }: MediaState) => {
   console.log("r0TurnMafiaUserCameraOff 수신");
 
-  allMediaSetting(tracks, false);
-  //NOTE -  1) 특정 유저의 track을 받아온다.
-  //NOTE -  2) 현재 방의 유저 중에 특정 user인지를 파악한다.
-  if (localUserId === userId) {
-    //NOTE -  3) 해당 특정 유저일 경우 track 및 boolean값을 통해 캠 활성화 및 비활성화
-    specificUserVideoSetting(specificUser, false);
+  if (!localUserId || !remoteParticipants || !players) {
+    return () => {};
   }
+  allMediaSetting(tracks, false);
+
+  // 2) 특정 유저의 track 및 boolean값을 통해 캠 활성화
+  const MafiaUserId = players.map((userId) => {
+    return remoteParticipants.map((remote) => {
+      if (remote.metadata === userId && localUserId === userId) {
+        return remote;
+      }
+    });
+  });
+  console.log("MafiaUserId", MafiaUserId);
 
   // 5초 후에 setStatus와 socket.emit 실행
   const r0TurnMafiaUserCameraOffTimer = setTimeout(async () => {


### PR DESCRIPTION
## 📌 관련 이슈
  closed #215 

## Task TODOLIST
- [ ] 원격 사용자의 카메라 기능 수정

## ✨ 개발 내용
```
기존 코드) livekit에서 제공해주는 useParticipantTracks(tracks[], userId) hook을 사용하여 특정 user의 카메라를 제어하였다.
현재 코드) useRemoteParticipants();  현재 방의 모든 원격 참가의 데이터인 track으로 코드 수정
이유) useEffect 내부에서 socket을 사용중이었고 hook 자체는 컴포넌트 최상위 루트에서 실행해야하므로 다른 조건으로 기능 수정
```
##  TroubleShotting
```
1. players[] 배열의 값을 setState값으로 전달 받음 
2. 전달받은 players의 배열에 map을 사용하여 각각의 userId에 해당 트랙(data)를 받아오려 하였다.
3. “Cannot read properties of undefined (reading 'length’)”에러가 발생
4.  처음에는 null값 문제로 생각하여 조건문을 통해 userId && sources라는 값이 있을 경우에만 map을 사용하게끔 유도하였지만 계속 문제가 발생하였다.  
5. 또한, Warning: React has detected a change in the order of Hooks called by MafiaPlayRooms. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks” 라는 문장 순서 error도 발생
6. 생각을 다르게 하여 1명의 원격 user가 아닌 전체의 원격 사용자의 데이터를 갖고오도록 수정하였다.
```
## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
[LiveKitDocs](https://docs.livekit.io/reference/components/react/)
