### PR TITLE
투표 시간 및 투표 결과를 서버와 연결

### DIFF
--- a/components/mafia/MafiaPlayRooms.tsx
+++ b/components/mafia/MafiaPlayRooms.tsx
@@ -222,7 +222,6 @@ const MafiaPlayRooms = () => {
     });
 
     // 의존성 배열에 votedPlayer, test.current 넣어 사용해봤지만 socket 내부 쪽에서는 상태 변화가 이루어지지 않는 걸 볼 수 있다.
-    // 그래서 useEffect를 분리 시켜 사용하였다.
     //NOTE - UI 모달창 띄우기: 마피아일 것 같은 사람의 화면을 클릭해주세요.(투표시간)
     socket.on("r1VoteToMafia", () => {
       r1VoteToMafiaModalHandler({
@@ -278,13 +277,8 @@ const MafiaPlayRooms = () => {
     };
   }, [tracks]);
 
-  //NOTE - 외존성 배열:
-  // title: 처음 동작 시기를 설정
-  // votedPlayer: 변화되는 값을 설정
-  // isVoted: 타이머 종료 후 다음 동작 설정
   useEffect(() => {
     if (title.includes("투표 시간")) {
-      //타이머 변수에 값 전달
       r1VoteToMafiaHandler({
         votedPlayer,
         isVoted,
@@ -299,6 +293,8 @@ const MafiaPlayRooms = () => {
 
     // 컴포넌트가 unmount되면 타이머를 클리어
     return () => clearTimeout(voteTimerClose);
+
+    // title: 처음 동작 시기를 설정, votedPlayer: 변화되는 값을 설정, isVoted: 타이머 종료 후 다음 동작 설정
   }, [title, votedPlayer, isVoted]);
 
   const checkClickHandle = (event: React.MouseEvent<HTMLElement>, participant: Participant, index: number) => {

--- a/components/mafia/MafiaPlayRooms.tsx
+++ b/components/mafia/MafiaPlayRooms.tsx
@@ -43,6 +43,9 @@ const MafiaPlayRooms = () => {
   const { title, setIsOpen, setTitle, setMessage, setTimer, setIsClose } = useShowModalStore();
   const [timerIds, setTimerIds] = useState<NodeJS.Timeout[]>([]); // 여러 setTimeout의 타이머 상태를 저장하여 return시 한번에 제거
   const [votedPlayer, setVotedPlayer] = useState("");
+  const [isVoted, setVoted] = useState(false);
+  const timerRef = useRef(false);
+  const [voteTimerClose, setVoteTimerClose] = useState<NodeJS.Timeout>();
 
   //NOTE -  전체 데이터
   const tracks = useTracks(
@@ -278,12 +281,25 @@ const MafiaPlayRooms = () => {
   //NOTE - 외존성 배열:
   // title: 처음 동작 시기를 설정
   // votedPlayer: 변화되는 값을 설정
+  // isVoted: 타이머 종료 후 다음 동작 설정
   useEffect(() => {
     if (title.includes("투표 시간")) {
-      console.log("OutState", votedPlayer);
-      r1VoteToMafiaHandler({ votedPlayer, setTimerIds, setIsOverlay, clearActiveParticipant });
+      //타이머 변수에 값 전달
+      r1VoteToMafiaHandler({
+        votedPlayer,
+        isVoted,
+        timerRef,
+        setVoteTimerClose,
+        setIsOverlay,
+        setVoted,
+        clearActiveParticipant
+      });
+      console.log("votedPlayer", votedPlayer);
     }
-  }, [title, votedPlayer]);
+
+    // 컴포넌트가 unmount되면 타이머를 클리어
+    return () => clearTimeout(voteTimerClose);
+  }, [title, votedPlayer, isVoted]);
 
   const checkClickHandle = (event: React.MouseEvent<HTMLElement>, participant: Participant, index: number) => {
     event.stopPropagation();

--- a/components/mafia/MafiaPlayRooms.tsx
+++ b/components/mafia/MafiaPlayRooms.tsx
@@ -164,7 +164,6 @@ const MafiaPlayRooms = () => {
 
     //NOTE -  (토론시간) 아침이 시작되었습니다 모달창 띄우기
     socket.on("r1MorningStart", () => {
-      clearActiveParticipant(); //캠 이미지 및 활성화된 user 정보 초기화
       r1MorningStartHandler({
         roomId,
         userId,
@@ -218,7 +217,9 @@ const MafiaPlayRooms = () => {
         clearActiveParticipant
       });
     });
-    // console.log("OutState", votedPlayer);
+
+    // 의존성 배열에 votedPlayer, test.current 넣어 사용해봤지만 socket 내부 쪽에서는 상태 변화가 이루어지지 않는 걸 볼 수 있다.
+    // 그래서 useEffect를 분리 시켜 사용하였다.
     //NOTE - UI 모달창 띄우기: 마피아일 것 같은 사람의 화면을 클릭해주세요.(투표시간)
     socket.on("r1VoteToMafia", () => {
       r1VoteToMafiaModalHandler({
@@ -230,15 +231,10 @@ const MafiaPlayRooms = () => {
         setIsOverlay,
         clearActiveParticipant
       });
-
-      // 의존성 배열에 votedPlayer, test.current 넣어 사용해봤지만 socket 내부쪽에서는 상태 변화가 이루어지지 않는 걸 볼 수 있다.
-      // console.log("state", votedPlayer);
     });
 
     //NOTE - UI 모달창 띄우기: 투표 개표(투표결과)
     socket.on("r1ShowVoteToResult", (voteBoard) => {
-      // console.log("state", votedPlayer);
-
       r1ShowVoteToResultHandler({
         roomId,
         userId,
@@ -279,12 +275,15 @@ const MafiaPlayRooms = () => {
     };
   }, [tracks]);
 
+  //NOTE - 외존성 배열:
+  // title: 처음 동작 시기를 설정
+  // votedPlayer: 변화되는 값을 설정
   useEffect(() => {
     if (title.includes("투표 시간")) {
       console.log("OutState", votedPlayer);
       r1VoteToMafiaHandler({ votedPlayer, setTimerIds, setIsOverlay, clearActiveParticipant });
     }
-  }, [votedPlayer]);
+  }, [title, votedPlayer]);
 
   const checkClickHandle = (event: React.MouseEvent<HTMLElement>, participant: Participant, index: number) => {
     event.stopPropagation();

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,7 +2,7 @@ import { TrackReference, TrackReferenceOrPlaceholder } from "@livekit/components
 import { User } from "@supabase/supabase-js";
 import { LocalParticipant, Participant, RemoteParticipant, Track } from "livekit-client";
 import { StaticImageData } from "next/image";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react";
 
 export interface MafiaRoom {
   room: string;
@@ -165,11 +165,17 @@ export interface TotalSocketState {
   setTimerIds: Dispatch<SetStateAction<NodeJS.Timeout[]>>;
   clearActiveParticipant: () => void;
 }
+
+export interface VoteState {
+  votedPlayer: string;
+  isVoted: boolean;
+  timerRef: MutableRefObject<boolean>;
+  setVoteTimerClose: Dispatch<SetStateAction<NodeJS.Timeout | undefined>>;
+  setIsOverlay: (newIsOverlay: boolean) => void;
+  clearActiveParticipant: () => void;
+  setVoted: (newIsVoted: boolean) => void;
+}
 export type SetModalState = Omit<TotalSocketState, "userId" | "roomId" | "votedPlayer" | "voteBoard" | "setTimerIds">;
-export type VoteState = Pick<
-  TotalSocketState,
-  "votedPlayer" | "setTimerIds" | "setIsOverlay" | "clearActiveParticipant"
->;
 
 export interface MediaState {
   tracks: TrackReferenceOrPlaceholder[];

--- a/utils/mafiaSocket/mafiaSocket.ts
+++ b/utils/mafiaSocket/mafiaSocket.ts
@@ -275,26 +275,25 @@ export const r1VoteToMafiaHandler = ({
   setVoted,
   clearActiveParticipant
 }: VoteState) => {
-  // 15초 후에 setStatus와 socket.emit 실행
-  // setTitle에 값을 넣을 시기에 ui쪽에서는 모달 창이 띄어지며 5초라는 시간이 흘러가므로 15초동안 투표하기 위해서는
-  // 위의 모달창 타이머를 포함한 시간인 20초를 넣어야한다.
+  // clearTimeout 변수 선언
   let r1VoteToMafiaTimer;
 
-  // setTimeout 함수를 한 번만 실행
-  // 캠 클릭시 마다 setTimeout이 새로 생성되어 유저별 동작이 달라진다.
+  // setTimeout 함수를 한 번만 실행(캠 클릭 시 마다 setTimeout이 새로 생성되어 유저별 동작이 달라진다.)
   if (!timerRef.current) {
     timerRef.current = true;
     console.log("작동 횟수 체크");
 
+    // 15초 후에 setStatus와 socket.emit 실행
+    // setTitle에 값을 넣을 시기에 ui쪽에서는 모달 창이 띄어지며 5초라는 시간이 흘러가므로 15초동안 투표하기 위해서는
+    // 위의 모달창 타이머를 포함한 시간인 20초를 넣어야한다.
     r1VoteToMafiaTimer = setTimeout(() => {
       setVoted(true);
       setIsOverlay(false); // 캠 클릭 이벤트 비활성화
       clearActiveParticipant(); // 캠 이미지 및 활성화된 user 정보 초기화
-    }, 10000);
+    }, 20000);
   }
 
   //타이머 종료 후 다음 동자을 실행
-  //votedPlayer의 최신 값을 인식하지 못한다.
   if (isVoted) {
     console.log("userId", votedPlayer);
     socket.emit("r1VoteToMafia", votedPlayer);

--- a/utils/mafiaSocket/mafiaSocket.ts
+++ b/utils/mafiaSocket/mafiaSocket.ts
@@ -162,7 +162,8 @@ export const r1MorningStartHandler = ({
   setMessage,
   setTimer,
   setIsOverlay,
-  setTimerIds
+  setTimerIds,
+  clearActiveParticipant
 }: TotalSocketState) => {
   console.log("r1MorningStart 수신");
 
@@ -205,6 +206,8 @@ export const r1FindMafiaHandler = ({
   setTimerIds
 }: TotalSocketState) => {
   console.log("r1FindMafia 수신");
+  setIsOverlay(false); //캠 클릭 이벤트 비활성화
+  // setTimer(60); UI에 보여질 타이머
 
   // 1분 후에 setStatus와 socket.emit 실행
   const r1FindMafiaTimer = setTimeout(() => {
@@ -245,7 +248,7 @@ export const r1MeetingOverHandler = ({
   setTimerIds((prevTimerIds: any) => [...prevTimerIds, r1MeetingOverTimer]);
 };
 
-//NOTE - UI 모달창 띄우기: 마피아일 것 같은 사람의 화면을 클릭해주세요.(투표시간)
+//NOTE - UI 모달창 띄우기: 투표시간 (마피아일 것 같은 사람의 화면을 클릭해주세요.)
 export const r1VoteToMafiaModalHandler = ({
   setIsOpen,
   setTitle,
@@ -262,9 +265,12 @@ export const r1VoteToMafiaModalHandler = ({
   console.log("r1VoteToMafia 수신");
 };
 
-//NOTE - 투표 시간에 클릭한 userId 값 전달
+//NOTE - 투표 시간의 캠 클릭 이벤트 핸들러 (userId 값 전달)
 export const r1VoteToMafiaHandler = ({ votedPlayer, setTimerIds, setIsOverlay, clearActiveParticipant }: VoteState) => {
   // 15초 후에 setStatus와 socket.emit 실행
+  // 의존성 배열에 title이라는 값을 넣어 초기 실행 조건을 맞췄다.
+  // setTitle에 값을 넣을 시기에 ui쪽에서는 모달 창이 띄어지며 5초라는 시간이 흘러가므로 15초동안 투표하기 위해서는
+  // 위의 모달창 타이머를 포함한 시간인 20초를 넣어야한다.
   const r1VoteToMafiaTimer = setTimeout(() => {
     console.log("votedPlayer", votedPlayer);
     socket.emit("r1VoteToMafia", votedPlayer);
@@ -303,7 +309,7 @@ export const r1ShowVoteToResultHandler = ({
   const r1ShowVoteToResultTimer = setTimeout(() => {
     socket.emit("r1ShowVoteToResult");
     console.log("r1ShowVoteToResult 송신");
-  }, 500);
+  }, 15000);
 
   // 생성된 타이머 ID를 저장
   setTimerIds((prevTimerIds: any) => [...prevTimerIds, r1ShowVoteToResultTimer]);

--- a/utils/mafiaSocket/mafiaSocket.ts
+++ b/utils/mafiaSocket/mafiaSocket.ts
@@ -266,21 +266,41 @@ export const r1VoteToMafiaModalHandler = ({
 };
 
 //NOTE - 투표 시간의 캠 클릭 이벤트 핸들러 (userId 값 전달)
-export const r1VoteToMafiaHandler = ({ votedPlayer, setTimerIds, setIsOverlay, clearActiveParticipant }: VoteState) => {
+export const r1VoteToMafiaHandler = ({
+  votedPlayer,
+  isVoted,
+  timerRef,
+  setVoteTimerClose,
+  setIsOverlay,
+  setVoted,
+  clearActiveParticipant
+}: VoteState) => {
   // 15초 후에 setStatus와 socket.emit 실행
-  // 의존성 배열에 title이라는 값을 넣어 초기 실행 조건을 맞췄다.
   // setTitle에 값을 넣을 시기에 ui쪽에서는 모달 창이 띄어지며 5초라는 시간이 흘러가므로 15초동안 투표하기 위해서는
   // 위의 모달창 타이머를 포함한 시간인 20초를 넣어야한다.
-  const r1VoteToMafiaTimer = setTimeout(() => {
-    console.log("votedPlayer", votedPlayer);
-    socket.emit("r1VoteToMafia", votedPlayer);
-    setIsOverlay(false); //캠 클릭 이벤트 비활성화
-    clearActiveParticipant(); //캠 이미지 및 활성화된 user 정보 초기화
-    console.log("r1VoteToMafia 송신");
-  }, 10000);
+  let r1VoteToMafiaTimer;
 
-  // 생성된 타이머 ID를 저장
-  setTimerIds((prevTimerIds: any) => [...prevTimerIds, r1VoteToMafiaTimer]);
+  // setTimeout 함수를 한 번만 실행
+  // 캠 클릭시 마다 setTimeout이 새로 생성되어 유저별 동작이 달라진다.
+  if (!timerRef.current) {
+    timerRef.current = true;
+    console.log("작동 횟수 체크");
+
+    r1VoteToMafiaTimer = setTimeout(() => {
+      setVoted(true);
+      setIsOverlay(false); // 캠 클릭 이벤트 비활성화
+      clearActiveParticipant(); // 캠 이미지 및 활성화된 user 정보 초기화
+    }, 10000);
+  }
+
+  //타이머 종료 후 다음 동자을 실행
+  //votedPlayer의 최신 값을 인식하지 못한다.
+  if (isVoted) {
+    console.log("userId", votedPlayer);
+    socket.emit("r1VoteToMafia", votedPlayer);
+    setVoteTimerClose(r1VoteToMafiaTimer);
+    console.log("r1VoteToMafia 송신");
+  }
 };
 
 //NOTE - UI 모달창 띄우기: 투표 개표(결과)
@@ -297,18 +317,33 @@ export const r1ShowVoteToResultHandler = ({
   setTimerIds
 }: TotalSocketState) => {
   console.log("r1ShowVoteToResult 수신");
-  console.log("투표 결과", voteBoard); //user_id, user_nickname, voted_count(내림차순)
+  console.log("투표 결과", voteBoard);
+
+  const manyVote = voteBoard[0].voted_count;
+  const nextVote = voteBoard[1].voted_count;
+  let socketEmitEvent = "";
+
+  //동등표일 경우(최후의 반론 및 투표 찬성 반대 스킵) ==> 밤으로 이동
+  if (manyVote === nextVote || manyVote === 0) {
+    setMessage("아무도 선택되지 않았습니다.");
+    socketEmitEvent = "r1TurnAllUserCameraMikeOff"; //밤이 되었습니다.
+  }
+
+  //가장 많은 투표를 받았을 경우
+  if (manyVote > nextVote && manyVote > 0) {
+    setMessage(`${voteBoard[0].user_nickname}님이 마피아로 지목되었습니다.`);
+    socketEmitEvent = "r1ShowVoteToResult";
+  }
 
   // 모달창 요소
   setIsOpen(true);
   setTitle("투표 결과");
-  setMessage(`${voteBoard.nickname}님이 마피아로 지목되었습니다.`);
   setTimer(5);
 
   // 15초 후에 setStatus와 socket.emit 실행
   const r1ShowVoteToResultTimer = setTimeout(() => {
-    socket.emit("r1ShowVoteToResult");
-    console.log("r1ShowVoteToResult 송신");
+    socket.emit(socketEmitEvent);
+    console.log(socketEmitEvent);
   }, 15000);
 
   // 생성된 타이머 ID를 저장


### PR DESCRIPTION
## 📌 관련 이슈
  closed #223 

## Task TODOLIST
- [x] 서버 socket과 연동
- [x] socket 송신과 수신 부분을 나누어 사용

## ✨ 개발 내용
```tsx
  //외존성 배열:
  // title: 처음 동작 시기를 설정
  // votedPlayer: 변화되는 값을 설정
  // isVoted: 타이머 종료 후 다음 동작 설정
  useEffect(() => {
    if (title.includes("투표 시간")) {
      //타이머 변수에 값 전달
      r1VoteToMafiaHandler({
        votedPlayer,
        isVoted,
        timerRef,
        setVoteTimerClose,
        setIsOverlay,
        setVoted,
        clearActiveParticipant
      });
      console.log("votedPlayer", votedPlayer);
    }

    // 컴포넌트가 unmount되면 타이머를 클리어
    return () => clearTimeout(voteTimerClose);
  }, [title, votedPlayer, isVoted]);
```
```tsx
//NOTE - 투표 시간의 캠 클릭 이벤트 핸들러 (userId 값 전달)
export const r1VoteToMafiaHandler = ({
  votedPlayer,
  isVoted,
  timerRef,
  setVoteTimerClose,
  setIsOverlay,
  setVoted,
  clearActiveParticipant
}: VoteState) => {
// clearTimeout 변수 선언
  let r1VoteToMafiaTimer;

  // setTimeout 함수를 한 번만 실행
  // 캠 클릭시 마다 setTimeout이 새로 생성되어 유저별 동작이 달라진다.
  if (!timerRef.current) {
    timerRef.current = true;

  // 10초 후에 setStatus와 socket.emit 실행
    r1VoteToMafiaTimer = setTimeout(() => {
      setVoted(true);       //시간 경과 후 다음 socket 실행
      setIsOverlay(false); // 캠 클릭 이벤트 비활성화
      clearActiveParticipant(); // 캠 이미지 및 활성화된 user 정보 초기화
    }, 10000);
  }

  //타이머 종료 후 다음 동자을 실행
  if (isVoted) {
    socket.emit("r1VoteToMafia", votedPlayer);
    setVoteTimerClose(r1VoteToMafiaTimer);
  }
};
```

##  TroubleShotting
```
1. 기존 하나의 useEffect를 분리 시켜 송신하는 부분과 수신하는 부분을 나누었으며, 송신하는 부분에서도 setTimeOut 부분과 시간 경과후 실행할 문장으로 나누었다.
이유는) setTimeout의 콜백 함수는 votedPlayer가 변경된 시점의 값이 아닌, 함수가 실행될 때의 값을 참조하기 때문이었다. 
2.  캠 클릭 시 setTimout이 갱신되어 다음 동작으로 넘어가지 않는 에러가 발생하였고 user 별로 각기 다른 동작이 발생하는 에러 또한 발생하였다. 이를 해결하기 위해 useRef에 boolean값을 주어 한 번만 실행하게끔 구성하였다.
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
(https://developer.mozilla.org/ko/docs/Web/API/setTimeout)
