### PR TITLE
[Fix #222] 마피아 게임 플레이 서버와 클라이언트, 데이터베이스 부분 수정

### DIFF
--- a/app/(withGlobalLayout)/mafia_play/page.tsx
+++ b/app/(withGlobalLayout)/mafia_play/page.tsx
@@ -349,10 +349,11 @@ const MafiaPlay = () => {
       console.log("[r1ShowMostVotedPlayerError]");
     });
 
-    socket.on("r1LastTalk", (message) => {
+    socket.on("r1LastTalk", (message, player) => {
       console.log("r1LastTalk 수신");
 
       console.log(`r1LastTalk ${message} 모달 창 띄움`);
+      console.log(`${player}가 유저 아이디`);
 
       socket.emit("r1LastTalk");
       console.log("r1LastTalk 송신");


### PR DESCRIPTION
## 📌 관련 이슈
closed #222

## Task TODOLIST
- [X] 마피아 게임 플레이 중복 실행을 막기 위해 서버 수정
- [ ] 마피아 게임 플레이 중복 실행을 막기 위해 클라이언트 수정
- [ ] 마피아 게임 플레이 중복 실행을 막기 위해 데이터베이스 수정

## ✨ 개발 내용
- 마피아 게임 플레이 중복 실행 방지를 위해 서버와 클라이언트, 데이터베이스 부분 수정

##  TroubleShotting
- 한번에 두 클라이언트가 DB 작업을 동시에 실행할 경우 게임이 2번 실행 되는 현상이 발생
- DB 작업 전과 후를 비교해서 두 클라이언트가 동시에 작업한다면 되돌리도록 기능 추가