### PR TITLE
[Fix #243] 커스텀 훅으로 만든 타이머 수정 완료

### DIFF
--- a/components/modal/GroupMafiaModal.tsx
+++ b/components/modal/GroupMafiaModal.tsx
@@ -1,19 +1,19 @@
 import { useCountDown } from "@/hooks/useCountDown";
-import useModal from "@/hooks/useModal";
 import useShowModalStore from "@/store/showModal.store";
 import S from "@/style/modal/modal.module.css";
+import { useEffect } from "react";
 
 const GroupMafiaModal = () => {
-  const { isOpen, timer, title, message, nickname } = useShowModalStore();
+  const { isOpen, timer, title, message, nickname, setTimer, setIsOpen } = useShowModalStore();
   const count = useCountDown(timer);
-  const { modalState } = useModal();
 
-  if (count === 0) {
-    return null;
-  }
-
-  //NOTE - 모달이 열리지 않았을 때 아무것도 랜더링 하지 않아야 함
-  if (!isOpen) return null;
+  // 모달창 종료 시점
+  useEffect(() => {
+    if (count === 0) {
+      setIsOpen(false);
+      console.log("ModalTime 종료", count);
+    }
+  }, [count]);
 
   return (
     <>

--- a/hooks/useCountDown.ts
+++ b/hooks/useCountDown.ts
@@ -1,46 +1,18 @@
-import useShowModalStore from "@/store/showModal.store";
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 
-export const useCountDown = (initialSecond: number) => {
-  const [count, setCount] = useState(initialSecond * 10);
-  const { setIsOpen } = useShowModalStore();
+export const useCountDown = (initialTime: number) => {
+  const [time, setTime] = useState(initialTime * 10);
 
   useEffect(() => {
-    let timer = initialSecond * 10;
-
-    const intervalId = setInterval(() => {
-      if (timer === 0) {
-        setIsOpen(false);
-        setCount(0);
-        clearInterval(intervalId);
-      } else {
-        timer--;
-        setCount((prev) => prev - 1);
-      }
-
-      if (timer <= 0) {
-        return;
-      }
+    const timer = setInterval(() => {
+      setTime((prevTime) => prevTime - 1);
     }, 100);
 
-    return () => clearInterval(intervalId);
-  }, []);
+    return () => {
+      console.log("useCountDown UnMount");
+      clearInterval(timer);
+    };
+  }, [initialTime]);
 
-  return count;
+  return time;
 };
-
-// import { useState, useEffect } from 'react';
-
-// function useTimer(initialTime) {
-//   const [time, setTime] = useState(initialTime);
-
-//   useEffect(() => {
-//     const timer = setInterval(() => {
-//       setTime((prevTime) => prevTime + 1);
-//     }, 1000);
-
-//     return () => clearInterval(timer);
-//   }, [initialTime]);
-
-//   return time;
-// }


### PR DESCRIPTION
## 📌 관련 이슈
  closed #243 

## Task TODOLIST
- [ ] useCountDown.ts

## ✨ 개발 내용
```tsx
import { useState, useEffect } from "react";

export const useCountDown = (initialTime: number) => {
  const [time, setTime] = useState(initialTime * 10);

  useEffect(() => {
    const timer = setInterval(() => {
      setTime((prevTime) => prevTime - 1);
    }, 100);

    return () => {
      console.log("useCountDown UnMount");
      clearInterval(timer);
    };
  }, [initialTime]);

  return time;
};



```
##  ✨TroubleShotting
```tsx
트러블 슈팅


새로 변경한 useCountDown Logic에 대한 내용
```tsx
import { useState, useEffect } from "react";

export const useCountDown = (initialTime: number) => {
  const [time, setTime] = useState(initialTime * 10);
  
  // * 10을 한 이유는 time 기능을 사용하는 곳: progress Bar
  // 기존) 1초단위의 Progress Bar에서는 툭툭 끊기는 모습을 볼 수 있었다.
  // 현재) 시간을 더 쪼갠 후 0.1초씩 흘러가게 설정

  useEffect(() => {
    
    const timer = setInterval(() => {
      setTime((prevCount) => {
        
        //타이머 0초일 경우 clear-up(타이머 정리)
        if (prevCount <= 0) {
          console.log("useCountDown 종료", prevCount);
          clearInterval(timer);
        }

        return prevCount - 1;
      });
    }, 100);

    return () => {
      //UnMount시 실행(안전용)
      clearInterval(timer);
    };
  }, [initialTime]);

  return time;
};


```
```tsx

//사용하는 모달 컴포넌트
const count = useCountDown(5);


    // 모달창 종료 시점
    if (count === 0) {
      setIsCreate(false);
      console.log("ModalTime 종료", count);
    }
```



문제: useCountDown.tsx의 state의 값이 처리되는 중(렌더링 되는중) 
모달 컴포넌트를 강제로 unMount시켜 useCountDown 컴포넌트 또한 강제 종료 시키는 문제가 발생하였다. 
> Warning: Cannot update a component (`Mainpage`) while rendering a different component  발생


### 해결: useEffect를 사용하여 렌더링의 순서를 변경하여 해결
```tsx
  // 모달창 종료 시점
  useEffect(() => {
    if (count === 0) {
      setIsOpen(false);
      console.log("ModalTime 종료", count);
    }
  }, [count]);


```
