### PR TITLE
[Feat #283] players의 초기 Ready 상태에 대한 socket Event 연결 

### DIFF
--- a/app/(withoutGlobalLayout)/room/[id]/page.tsx
+++ b/app/(withoutGlobalLayout)/room/[id]/page.tsx
@@ -3,14 +3,11 @@
 import JoinMafiaRoom from "@/components/mafia/JoinMafiaRoom";
 import Loading from "@/components/layout/Loading";
 import { useExitStore } from "@/store/exit-store";
-import { useEffect } from "react";
 
 const RoomPage = () => {
-  const { isExit, setIsExit } = useExitStore();
+  const { isExit } = useExitStore();
 
-  useEffect(() => {
-    setIsExit(false);
-  }, []);
+  console.log("RoomPage 작동", isExit);
 
   return <>{isExit ? <Loading /> : <JoinMafiaRoom />}</>;
 };

--- a/app/(withoutGlobalLayout)/room/[id]/page.tsx
+++ b/app/(withoutGlobalLayout)/room/[id]/page.tsx
@@ -7,8 +7,6 @@ import { useExitStore } from "@/store/exit-store";
 const RoomPage = () => {
   const { isExit } = useExitStore();
 
-  console.log("RoomPage 작동", isExit);
-
   return <>{isExit ? <Loading /> : <JoinMafiaRoom />}</>;
 };
 

--- a/app/livekit/get-participant-token/route.ts
+++ b/app/livekit/get-participant-token/route.ts
@@ -21,7 +21,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Server misconfigured" }, { status: 500 });
   }
 
-  const at = new AccessToken(apiKey, apiSecret, { identity: userId, name: nickname });
+  const at = new AccessToken(apiKey, apiSecret, { identity: userId, name: nickname, metadata: room });
 
   at.addGrant({ room, roomJoin: true, canPublish: true, canSubscribe: true });
 

--- a/components/layout/Loading.tsx
+++ b/components/layout/Loading.tsx
@@ -1,9 +1,25 @@
-import Image from "next/image";
-import React from "react";
-import S from "@/style/commons/commons.module.css";
 import { designer } from "@/public/fonts/fonts";
+import { useExitStore } from "@/store/exit-store";
+import S from "@/style/commons/commons.module.css";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 const Loading = () => {
+  const router = useRouter();
+  const { setIsExit } = useExitStore();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsExit(false);
+      console.log("Loading 컴포넌트 작동", timer);
+      router.replace("/main");
+    }, 3000);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <section className={`${S.loadingWrapper} ${designer.className}`}>
       <div>IceCraft</div>

--- a/components/layout/Loading.tsx
+++ b/components/layout/Loading.tsx
@@ -10,12 +10,11 @@ const Loading = () => {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      setIsExit(false);
-      console.log("Loading 컴포넌트 작동", timer);
       router.replace("/main");
     }, 3000);
 
     return () => {
+      setIsExit(false);
       clearTimeout(timer);
     };
   }, []);

--- a/components/mafia/GameStartButton.tsx
+++ b/components/mafia/GameStartButton.tsx
@@ -1,5 +1,6 @@
 import useSocketOn from "@/hooks/useSocketOn";
 import { useGameActions, useIsReady } from "@/store/game-store";
+import { useOverLayActions } from "@/store/overlay-store";
 import { socket } from "@/utils/socket/socket";
 import { useLocalParticipant, useParticipants } from "@livekit/components-react";
 import { useState } from "react";
@@ -7,7 +8,8 @@ import { useState } from "react";
 const GameStartButton = () => {
   const [isAllReady, setIsAllReady] = useState(false);
   const isReady = useIsReady();
-  const { setIsReady } = useGameActions();
+  const { setIsReady, setIsStart } = useGameActions();
+  const { clearActiveImage } = useOverLayActions();
 
   const participants = useParticipants();
   const { localParticipant } = useLocalParticipant();
@@ -26,6 +28,11 @@ const GameStartButton = () => {
   //NOTE - 게임 시작 이벤트 핸들러
   const startHandler = () => {
     socket.emit("gameStart", roomId, playersCount);
+
+    // 버튼 비활성화
+    setIsStart(false);
+    // 이미지 초기화clearActiveImage
+    clearActiveImage();
   };
 
   //NOTE - 방장일 경우에만 "게임시작 버튼" 활성화

--- a/components/mafia/GameStartButton.tsx
+++ b/components/mafia/GameStartButton.tsx
@@ -1,42 +1,10 @@
 import useSocketOn from "@/hooks/useSocketOn";
-import { useGameActions, useIsReady } from "@/store/game-store";
-import { useOverLayActions } from "@/store/overlay-store";
-import { socket } from "@/utils/socket/socket";
-import { useLocalParticipant, useParticipants } from "@livekit/components-react";
+import { useIsReady } from "@/store/game-store";
 import { useState } from "react";
 
-const GameStartButton = () => {
+const GameStartButton = ({ readyHandler, startHandler }: any) => {
   const [isAllReady, setIsAllReady] = useState(false);
   const isReady = useIsReady();
-  const { setIsReady, setIsStart } = useGameActions();
-  const { clearActiveImage } = useOverLayActions();
-
-  const participants = useParticipants();
-  const { localParticipant } = useLocalParticipant();
-  const playersCount = participants.length;
-  const userId = localParticipant.identity;
-  const roomId = localParticipant.metadata;
-
-  //NOTE - 게임 준비 이벤트 핸들러
-  const readyHandler = () => {
-    const newIsReady = !isReady;
-    setIsReady(newIsReady);
-
-    socket.emit("setReady", userId, newIsReady);
-  };
-
-  //NOTE - 게임 시작 이벤트 핸들러
-  //NOTE - 서버에서 게임 실행 조건을 충족 되었을 경우 "chiefStart"라는 socket Event를 전달하여 게임 시작버튼을 활성화 시키므로 유효성검사는 충족되어 별도로
-  const startHandler = () => {
-    socket.emit("gameStart", roomId, playersCount);
-
-    // 버튼 비활성화
-    setIsStart(true);
-
-    // 이미지 초기화clearActiveImage
-    clearActiveImage();
-    setIsReady(false);
-  };
 
   //NOTE - 방장일 경우에만 "게임시작 버튼" 활성화 및 비활성화
   const sockets = {

--- a/components/mafia/GameStartButton.tsx
+++ b/components/mafia/GameStartButton.tsx
@@ -1,12 +1,11 @@
-import { useGameActions, useIsReady } from "@/store/game-store";
-import useConnectStore from "@/store/connect-store";
-import { socket } from "@/utils/socket/socket";
-import { useState } from "react";
-import { useLocalParticipant, useParticipants } from "@livekit/components-react";
 import useSocketOn from "@/hooks/useSocketOn";
+import { useGameActions, useIsReady } from "@/store/game-store";
+import { socket } from "@/utils/socket/socket";
+import { useLocalParticipant, useParticipants } from "@livekit/components-react";
+import { useState } from "react";
 
 const GameStartButton = () => {
-  const [isStart, setIsStart] = useState(false);
+  const [isAllReady, setIsAllReady] = useState(false);
   const isReady = useIsReady();
   const { setIsReady } = useGameActions();
 
@@ -19,8 +18,8 @@ const GameStartButton = () => {
   //NOTE - 게임 준비 이벤트 핸들러
   const readyHandler = () => {
     const newIsReady = !isReady;
-
     setIsReady(newIsReady);
+
     socket.emit("setReady", userId, newIsReady);
   };
 
@@ -33,7 +32,7 @@ const GameStartButton = () => {
   const sockets = {
     chiefStart: () => {
       console.log("니가 방장이다");
-      setIsStart(true);
+      setIsAllReady(true);
     }
   };
 
@@ -41,10 +40,13 @@ const GameStartButton = () => {
 
   return (
     <>
-      <button style={{ backgroundColor: isReady ? "#5c5bad" : "#bfbfbf" }} onClick={readyHandler}>
-        {isReady ? "취소" : "게임 준비"}
-      </button>
-      {isStart && playersCount === 5 && <button onClick={startHandler}>게임시작</button>}
+      {isAllReady && <button onClick={startHandler}>게임시작</button>}
+
+      {!isAllReady && (
+        <button style={{ backgroundColor: isReady ? "#5c5bad" : "#bfbfbf" }} onClick={readyHandler}>
+          {isReady ? "취소" : "게임 준비"}
+        </button>
+      )}
     </>
   );
 };

--- a/components/mafia/GameStartButton.tsx
+++ b/components/mafia/GameStartButton.tsx
@@ -6,18 +6,19 @@ import { useLocalParticipant, useParticipants } from "@livekit/components-react"
 import useSocketOn from "@/hooks/useSocketOn";
 
 const GameStartButton = () => {
-  const { roomId } = useConnectStore();
-  const participants = useParticipants();
   const [isStart, setIsStart] = useState(false);
-  const { localParticipant } = useLocalParticipant();
-
   const isReady = useIsReady();
   const { setIsReady } = useGameActions();
+
+  const participants = useParticipants();
+  const { localParticipant } = useLocalParticipant();
+  const playersCount = participants.length;
+  const userId = localParticipant.identity;
+  const roomId = localParticipant.metadata;
 
   //NOTE - 게임 준비 이벤트 핸들러
   const readyHandler = () => {
     const newIsReady = !isReady;
-    const userId = localParticipant.identity;
 
     setIsReady(newIsReady);
     socket.emit("setReady", userId, newIsReady);
@@ -25,14 +26,13 @@ const GameStartButton = () => {
 
   //NOTE - 게임 시작 이벤트 핸들러
   const startHandler = () => {
-    const playersCount = participants.length;
-
     socket.emit("gameStart", roomId, playersCount);
   };
 
   //NOTE - 방장일 경우에만 "게임시작 버튼" 활성화
   const sockets = {
     chiefStart: () => {
+      console.log("니가 방장이다");
       setIsStart(true);
     }
   };
@@ -44,7 +44,7 @@ const GameStartButton = () => {
       <button style={{ backgroundColor: isReady ? "#5c5bad" : "#bfbfbf" }} onClick={readyHandler}>
         {isReady ? "취소" : "게임 준비"}
       </button>
-      {isStart && <button onClick={startHandler}>게임시작</button>}
+      {isStart && playersCount === 5 && <button onClick={startHandler}>게임시작</button>}
     </>
   );
 };

--- a/components/mafia/GameStartButton.tsx
+++ b/components/mafia/GameStartButton.tsx
@@ -1,10 +1,8 @@
 import useSocketOn from "@/hooks/useSocketOn";
-import { useIsReady } from "@/store/game-store";
 import { useState } from "react";
 
-const GameStartButton = ({ readyHandler, startHandler }: any) => {
+const GameStartButton = ({ isReady, readyHandler, startHandler }: any) => {
   const [isAllReady, setIsAllReady] = useState(false);
-  const isReady = useIsReady();
 
   //NOTE - 방장일 경우에만 "게임시작 버튼" 활성화 및 비활성화
   const sockets = {
@@ -19,7 +17,6 @@ const GameStartButton = ({ readyHandler, startHandler }: any) => {
       }
     }
   };
-
   useSocketOn(sockets);
 
   return (

--- a/components/mafia/GameStartButton.tsx
+++ b/components/mafia/GameStartButton.tsx
@@ -26,20 +26,29 @@ const GameStartButton = () => {
   };
 
   //NOTE - 게임 시작 이벤트 핸들러
+  //NOTE - 서버에서 게임 실행 조건을 충족 되었을 경우 "chiefStart"라는 socket Event를 전달하여 게임 시작버튼을 활성화 시키므로 유효성검사는 충족되어 별도로
   const startHandler = () => {
     socket.emit("gameStart", roomId, playersCount);
 
     // 버튼 비활성화
-    setIsStart(false);
+    setIsStart(true);
+
     // 이미지 초기화clearActiveImage
     clearActiveImage();
+    setIsReady(false);
   };
 
-  //NOTE - 방장일 경우에만 "게임시작 버튼" 활성화
+  //NOTE - 방장일 경우에만 "게임시작 버튼" 활성화 및 비활성화
   const sockets = {
-    chiefStart: () => {
-      console.log("니가 방장이다");
-      setIsAllReady(true);
+    chiefStart: (isStart: boolean) => {
+      if (isStart) {
+        console.log("니가 방장이며, 게임 시작할 수 있다.");
+        setIsAllReady(true);
+      }
+      if (!isStart) {
+        console.log("니가 방장이지만, 게임 시작할 수 없다.");
+        setIsAllReady(false);
+      }
     }
   };
 

--- a/components/mafia/JoinMafiaRoom.tsx
+++ b/components/mafia/JoinMafiaRoom.tsx
@@ -7,7 +7,7 @@ import BeforeUnloadHandler from "@/utils/reload/beforeUnloadHandler";
 import { LiveKitRoom, PreJoin, RoomAudioRenderer } from "@livekit/components-react";
 import "@livekit/components-styles";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const JoinMafiaRoom = () => {
   const [isJoin, setIsJoin] = useState(false);
@@ -61,19 +61,14 @@ const JoinMafiaRoom = () => {
           <div className={S.settingCam}>
             <PreJoin
               onError={(err) => console.log("setting error", err)}
-              defaults={{
-                username: "",
-                videoEnabled: true,
-                audioEnabled: true
-              }}
               joinLabel="입장하기"
-              onSubmit={() => setIsJoin(true)}
-              onValidate={() => true}
+              onSubmit={() => setIsJoin(true)} // 입장하기 버튼 이벤트 헨들러
+              onValidate={() => true} // 입장하기 버튼 활성화
             ></PreJoin>
             <div className={S.settingUserButton}>
               <ul>
-                <li>오디오 설정 확인</li>
-                <li>캠 설정 확인</li>
+                <li>오디오 설정 </li>
+                <li>캠 설정 </li>
               </ul>
             </div>
             <div className={S.cover}></div>

--- a/components/mafia/JoinMafiaRoom.tsx
+++ b/components/mafia/JoinMafiaRoom.tsx
@@ -1,19 +1,15 @@
 import MafiaPlayRooms from "@/components/mafia/MafiaPlayRooms";
 import { useGetToken } from "@/hooks/useToken";
 import useConnectStore from "@/store/connect-store";
-import { useExitStore } from "@/store/exit-store";
 import S from "@/style/livekit/livekit.module.css";
 import BeforeUnloadHandler from "@/utils/reload/beforeUnloadHandler";
-import { LiveKitRoom, PreJoin, RoomAudioRenderer } from "@livekit/components-react";
+import { LiveKitRoom, PreJoin } from "@livekit/components-react";
 import "@livekit/components-styles";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 const JoinMafiaRoom = () => {
   const [isJoin, setIsJoin] = useState(false);
   const { roomId, userId, nickname } = useConnectStore();
-  const { setIsExit } = useExitStore();
-  const router = useRouter();
   BeforeUnloadHandler();
 
   const { data: token, isPending, isSuccess, isError } = useGetToken(roomId, userId, nickname);
@@ -26,20 +22,6 @@ const JoinMafiaRoom = () => {
     console.log("토큰 발급중 에러 발생");
   }
 
-  //NOTE - 방을 나갈 시에 작동되는 이벤트 헨들러
-  // supabase의 성능문제를 해결하기위해 로딩창을 띄어 텀을 주었다.
-  const disConnected = () => {
-    setIsExit(true);
-
-    const timer = setTimeout(() => {
-      router.replace("/main");
-    }, 3000);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  };
-
   return (
     <main data-lk-theme="default">
       {isJoin ? (
@@ -49,11 +31,8 @@ const JoinMafiaRoom = () => {
           video={true}
           audio={true}
           connect={true}
-          onDisconnected={disConnected}
         >
           <MafiaPlayRooms />
-          {/* 원격 참가자의 오디오 트랙을 처리 및 관리 */}
-          <RoomAudioRenderer muted={false} />
         </LiveKitRoom>
       ) : (
         <section className={S.settingWrapper}>

--- a/components/mafia/JoinMafiaRoom.tsx
+++ b/components/mafia/JoinMafiaRoom.tsx
@@ -3,6 +3,7 @@ import { useGetToken } from "@/hooks/useToken";
 import useConnectStore from "@/store/connect-store";
 import S from "@/style/livekit/livekit.module.css";
 import BeforeUnloadHandler from "@/utils/reload/beforeUnloadHandler";
+import { socket } from "@/utils/socket/socket";
 import { LiveKitRoom, PreJoin } from "@livekit/components-react";
 import "@livekit/components-styles";
 import { useState } from "react";
@@ -20,6 +21,10 @@ const JoinMafiaRoom = () => {
 
   if (isError) {
     console.log("토큰 발급중 에러 발생");
+  }
+  // 입장 시 players의 Ready 상태를 받는 socket Event
+  if (isJoin) {
+    socket.emit("usersInfo", roomId);
   }
 
   return (

--- a/components/mafia/JoinMafiaRoom.tsx
+++ b/components/mafia/JoinMafiaRoom.tsx
@@ -3,13 +3,13 @@ import { useGetToken } from "@/hooks/useToken";
 import useConnectStore from "@/store/connect-store";
 import S from "@/style/livekit/livekit.module.css";
 import BeforeUnloadHandler from "@/utils/reload/beforeUnloadHandler";
-import { socket } from "@/utils/socket/socket";
 import { LiveKitRoom, PreJoin } from "@livekit/components-react";
 import "@livekit/components-styles";
 import { useState } from "react";
 
 const JoinMafiaRoom = () => {
   const [isJoin, setIsJoin] = useState(false);
+
   const { roomId, userId, nickname } = useConnectStore();
   BeforeUnloadHandler();
 
@@ -21,10 +21,6 @@ const JoinMafiaRoom = () => {
 
   if (isError) {
     console.log("토큰 발급중 에러 발생");
-  }
-  // 입장 시 players의 Ready 상태를 받는 socket Event
-  if (isJoin) {
-    socket.emit("usersInfo", roomId);
   }
 
   return (

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -14,7 +14,7 @@ import SpeakTimer from "./SpeakTimer";
 
 const LocalParticipant: React.FC<Participants> = ({ tracks }) => {
   const { localParticipant } = useLocalParticipant();
-  const { clearActiveImage } = useOverLayActions();
+  const { setOverlayReset } = useOverLayActions();
   const isLocalOverlay = useIsLocalOverlay();
   const { clickHandler } = useClickHandler();
   const activePlayerId = useActivePlayer();
@@ -43,10 +43,12 @@ const LocalParticipant: React.FC<Participants> = ({ tracks }) => {
   const startHandler = () => {
     socket.emit("gameStart", roomId, playersCount);
 
-    // 게임 버튼 비활성화 및 이미지 초기화
+    // 게임 버튼 비활성화
     setIsStartButton(false);
+
+    //local, remote 이미지 초기화
     setIsReady(false);
-    clearActiveImage();
+    setOverlayReset();
   };
 
   return (
@@ -69,7 +71,7 @@ const LocalParticipant: React.FC<Participants> = ({ tracks }) => {
           )}
         </div>
       </TrackLoop>
-      {isStartButton && <GameStartButton readyHandler={readyHandler} startHandler={startHandler} />}
+      {isStartButton && <GameStartButton isReady={isReady} readyHandler={readyHandler} startHandler={startHandler} />}
     </div>
   );
 };

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -23,8 +23,6 @@ const LocalParticipant: React.FC<Participants> = ({ tracks }) => {
   const localTracks = tracks.filter((track) => track.participant.sid === localParticipant.sid);
   const diedPlayer = diedPlayers.find((diedPlayer) => diedPlayer === localParticipant.identity);
 
-  console.log("activePlayerId", isReady);
-
   return (
     <div className={S.localParticipant}>
       <SpeakTimer />

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -1,7 +1,7 @@
 import CamCheck from "@/assets/images/cam_check.svg";
 import PlayerDieImage from "@/assets/images/player_die.svg";
 import useClickHandler from "@/hooks/useClickHandler";
-import { useDiedPlayer, useIsReady } from "@/store/game-store";
+import { useDiedPlayer, useIsReady, useIsStart } from "@/store/game-store";
 import { useActivePlayer, useIsLocalOverlay } from "@/store/overlay-store";
 import S from "@/style/livekit/livekit.module.css";
 import { Participants } from "@/types";
@@ -16,6 +16,7 @@ const LocalParticipant: React.FC<Participants> = ({ tracks }) => {
   const activePlayerId = useActivePlayer();
   const isLocalOverlay = useIsLocalOverlay();
   const isReady = useIsReady();
+  const isStart = useIsStart();
   const { clickHandler } = useClickHandler();
   const diedPlayers = useDiedPlayer();
 
@@ -42,7 +43,7 @@ const LocalParticipant: React.FC<Participants> = ({ tracks }) => {
           )}
         </div>
       </TrackLoop>
-      <GameStartButton />
+      {!isStart && <GameStartButton />}
     </div>
   );
 };

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -23,6 +23,8 @@ const LocalParticipant: React.FC<Participants> = ({ tracks }) => {
   const localTracks = tracks.filter((track) => track.participant.sid === localParticipant.sid);
   const diedPlayer = diedPlayers.find((diedPlayer) => diedPlayer === localParticipant.identity);
 
+  console.log("activePlayerId", isReady);
+
   return (
     <div className={S.localParticipant}>
       <SpeakTimer />

--- a/components/mafia/MafiaPlayRooms.tsx
+++ b/components/mafia/MafiaPlayRooms.tsx
@@ -12,6 +12,7 @@ import LocalParticipant from "./LocalParticipant";
 import MafiaModals from "./MafiaModals";
 import MafiaToolTip from "./MafiaToolTip";
 import RemoteParticipant from "./RemoteParticipant";
+import { useEffect } from "react";
 
 const MafiaPlayRooms = () => {
   const { localParticipant } = useLocalParticipant();

--- a/components/mafia/MafiaPlayRooms.tsx
+++ b/components/mafia/MafiaPlayRooms.tsx
@@ -1,21 +1,26 @@
 import useMediaSocket from "@/hooks/useMediaSocket";
-import useConnectStore from "@/store/connect-store";
+import useSelectSocket from "@/hooks/useSelectSocket";
+import useSocketOn from "@/hooks/useSocketOn";
+import { useExitStore } from "@/store/exit-store";
+import { useGameActions } from "@/store/game-store";
 import S from "@/style/livekit/livekit.module.css";
 import { allAudioSetting } from "@/utils/participantCamSettings/camSetting";
 import { socket } from "@/utils/socket/socket";
-import { DisconnectButton, useTracks } from "@livekit/components-react";
+import { DisconnectButton, RoomAudioRenderer, useLocalParticipant, useTracks } from "@livekit/components-react";
 import { Track } from "livekit-client";
 import LocalParticipant from "./LocalParticipant";
+import MafiaModals from "./MafiaModals";
 import MafiaToolTip from "./MafiaToolTip";
 import RemoteParticipant from "./RemoteParticipant";
-import useSelectSocket from "@/hooks/useSelectSocket";
-import useSocketOn from "@/hooks/useSocketOn";
-import { useGameActions } from "@/store/game-store";
-import MafiaModals from "./MafiaModals";
 
 const MafiaPlayRooms = () => {
-  const { userId, roomId } = useConnectStore();
+  const { localParticipant } = useLocalParticipant();
+  const roomId = localParticipant.metadata;
+  const userId = localParticipant.identity;
+
   const { setDiedPlayer } = useGameActions();
+  const { setIsExit } = useExitStore();
+
   useMediaSocket(); // 카메라 및 오디오 처리
   useSelectSocket(); // 클릭 이벤트 처리
 
@@ -38,7 +43,9 @@ const MafiaPlayRooms = () => {
   useSocketOn(sockets);
 
   //NOTE - 방 나가기 이벤트 헨들러
+  // supabase의 성능문제를 해결하기위해 로딩창을 띄어 텀을 주었다.
   const leaveRoom = () => {
+    setIsExit(true);
     socket.emit("exitRoom", roomId, userId);
   };
 
@@ -46,6 +53,8 @@ const MafiaPlayRooms = () => {
     <section className={S.section}>
       <LocalParticipant tracks={tracks} />
       <RemoteParticipant tracks={tracks} />
+      {/* 원격 참가자의 오디오 트랙을 처리 및 관리 */}
+      <RoomAudioRenderer muted={false} />
       <div className={S.goToMainPage}>
         <button
           onClick={() => {

--- a/components/mafia/MafiaPlayRooms.tsx
+++ b/components/mafia/MafiaPlayRooms.tsx
@@ -2,7 +2,6 @@ import useMediaSocket from "@/hooks/useMediaSocket";
 import useConnectStore from "@/store/connect-store";
 import S from "@/style/livekit/livekit.module.css";
 import { allAudioSetting } from "@/utils/participantCamSettings/camSetting";
-import BeforeUnloadHandler from "@/utils/reload/beforeUnloadHandler";
 import { socket } from "@/utils/socket/socket";
 import { DisconnectButton, useTracks } from "@livekit/components-react";
 import { Track } from "livekit-client";
@@ -42,9 +41,6 @@ const MafiaPlayRooms = () => {
   const leaveRoom = () => {
     socket.emit("exitRoom", roomId, userId);
   };
-
-  //NOTE - 뒤로가기 및 새로고침(미완성)
-  BeforeUnloadHandler();
 
   return (
     <section className={S.section}>

--- a/components/mafia/RemoteParticipant.tsx
+++ b/components/mafia/RemoteParticipant.tsx
@@ -1,19 +1,48 @@
 import S from "@/style/livekit/livekit.module.css";
-import { Participants } from "@/types";
+import { Participants, playersInfo } from "@/types";
 import { TrackLoop, useLocalParticipant } from "@livekit/components-react";
-import React from "react";
+import React, { useEffect } from "react";
 import RemoteParticipantTile from "./RemoteParticipantTile";
+import { useOverLayActions } from "@/store/overlay-store";
+import useSocketOn from "@/hooks/useSocketOn";
+import { socket } from "@/utils/socket/socket";
 
 const RemoteParticipant: React.FC<Participants> = ({ tracks }) => {
   const { localParticipant } = useLocalParticipant();
+  const { setReadyPlayers } = useOverLayActions();
+  const roomId = localParticipant.metadata;
 
-  const filteredTracks = tracks.filter(
+  const remotesTrack = tracks.filter(
     (track) => track.source === "camera" && track.participant.sid !== localParticipant.sid
   );
 
+  useEffect(() => {
+    //NOTE - 방 입장 시 한 번만 실행 && Remote Player가 존재할 경우에만 실행
+    if (roomId && remotesTrack.length !== 0) {
+      socket.emit("usersInfo", roomId);
+      console.log("usersInfo socket.emit 실행");
+    }
+  }, [roomId]);
+
+  const sockets = {
+    //NOTE - players의 실시간 준비 상태 update
+    setReady: (playerId: string, isReady: boolean) => {
+      setReadyPlayers(playerId, isReady);
+    },
+    //NOTE - players의 Ready 초기 상태
+    usersInfo: (players: playersInfo[]) => {
+      players.forEach((player) => {
+        if (player.is_ready) {
+          setReadyPlayers(player.user_id, player.is_ready);
+        }
+      });
+    }
+  };
+  useSocketOn(sockets);
+
   return (
     <ul className={S.remoteParticipant}>
-      <TrackLoop tracks={filteredTracks}>
+      <TrackLoop tracks={remotesTrack}>
         <RemoteParticipantTile />
       </TrackLoop>
     </ul>

--- a/components/mafia/RemoteParticipant.tsx
+++ b/components/mafia/RemoteParticipant.tsx
@@ -1,31 +1,15 @@
-import { useIsStart } from "@/store/game-store";
 import S from "@/style/livekit/livekit.module.css";
 import { Participants } from "@/types";
-import { TrackLoop, TrackReferenceOrPlaceholder, useLocalParticipant } from "@livekit/components-react";
-import React, { useState } from "react";
+import { TrackLoop, useLocalParticipant } from "@livekit/components-react";
+import React from "react";
 import RemoteParticipantTile from "./RemoteParticipantTile";
 
 const RemoteParticipant: React.FC<Participants> = ({ tracks }) => {
-  const isStart = useIsStart();
-  const [remoteTracks, setRemoteTracks] = useState<TrackReferenceOrPlaceholder[]>([]);
   const { localParticipant } = useLocalParticipant();
 
   const filteredTracks = tracks.filter(
     (track) => track.source === "camera" && track.participant.sid !== localParticipant.sid
   );
-
-  //NOTE -  게임 시작 전까지 track에 대한 정보를 state 값에 저장
-  // useEffect(() => {
-  //   // 게임 시작 이후부터는 state값을 유지
-  //   if (isStart) {
-  //     return;
-  //   }
-
-  //   const filteredTracks = tracks.filter(
-  //     (track) => track.source === "camera" && track.participant.sid !== localParticipant.sid
-  //   );
-  //   setRemoteTracks(filteredTracks);
-  // }, [tracks, isStart]);
 
   return (
     <ul className={S.remoteParticipant}>

--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -5,8 +5,10 @@ import { useDiedPlayer } from "@/store/game-store";
 import { useJobImageState } from "@/store/image-store";
 import { useActivePlayer, useIsRemoteOverlay, useOverLayActions, useReadyPlayers } from "@/store/overlay-store";
 import S from "@/style/livekit/livekit.module.css";
+import { socket } from "@/utils/socket/socket";
 import { ParticipantTile, ParticipantTileProps, useEnsureTrackRef } from "@livekit/components-react";
 import Image from "next/image";
+import { useEffect } from "react";
 
 const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   const trackReference = useEnsureTrackRef(trackRef);
@@ -30,6 +32,7 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   useSocketOn(sockets);
 
   //NOTE - remotePlayer의 Ready 초기 상태
+  socket.on("userInfo", () => {});
 
   if (!trackReference) {
     return null;

--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -15,20 +15,18 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   const PlayerId = useActivePlayer();
   const imageState = useJobImageState();
   const isRemoteOverlay = useIsRemoteOverlay();
-  const { clickHandler } = useClickHandler();
   const remoteReadyStates = useReadyPlayers();
+  const { clickHandler } = useClickHandler();
   const { setReadyPlayers } = useOverLayActions();
-  const [,] = useState<RemoteReadyStates>({});
 
   const diedPlayers = useDiedPlayer();
   const diedPlayer = diedPlayers.find((diedPlayer) => diedPlayer === trackReference.participant.identity);
 
   //NOTE - players의 실시간 준비 상태 update
   const sockets = {
-    setReady: (userId: string, isReady: boolean) => {
-      // setRemoteReadyStates((prev) => ({ ...prev, [userId]: isReady }));
+    setReady: (playerId: string, isReady: boolean) => {
       console.log("너 작동하니?");
-      setReadyPlayers(userId, isReady);
+      setReadyPlayers(playerId, isReady);
     }
   };
 

--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -5,10 +5,8 @@ import { useDiedPlayer } from "@/store/game-store";
 import { useJobImageState } from "@/store/image-store";
 import { useActivePlayer, useIsRemoteOverlay, useOverLayActions, useReadyPlayers } from "@/store/overlay-store";
 import S from "@/style/livekit/livekit.module.css";
-import { RemoteReadyStates } from "@/types";
 import { ParticipantTile, ParticipantTileProps, useEnsureTrackRef } from "@livekit/components-react";
 import Image from "next/image";
-import { useState } from "react";
 
 const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   const trackReference = useEnsureTrackRef(trackRef);
@@ -25,12 +23,9 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   //NOTE - players의 실시간 준비 상태 update
   const sockets = {
     setReady: (playerId: string, isReady: boolean) => {
-      console.log("너 작동하니?");
       setReadyPlayers(playerId, isReady);
     }
   };
-
-  console.log("remoteReadyStates", remoteReadyStates);
 
   useSocketOn(sockets);
 

--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -1,38 +1,22 @@
 import PlayerDieImages from "@/assets/images/player_die.svg";
 import useClickHandler from "@/hooks/useClickHandler";
-import useSocketOn from "@/hooks/useSocketOn";
 import { useDiedPlayer } from "@/store/game-store";
 import { useJobImageState } from "@/store/image-store";
-import { useActivePlayer, useIsRemoteOverlay, useOverLayActions, useReadyPlayers } from "@/store/overlay-store";
+import { useActivePlayer, useIsRemoteOverlay, useReadyPlayers } from "@/store/overlay-store";
 import S from "@/style/livekit/livekit.module.css";
-import { socket } from "@/utils/socket/socket";
 import { ParticipantTile, ParticipantTileProps, useEnsureTrackRef } from "@livekit/components-react";
 import Image from "next/image";
-import { useEffect } from "react";
 
 const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   const trackReference = useEnsureTrackRef(trackRef);
   const PlayerId = useActivePlayer();
+  const diedPlayers = useDiedPlayer();
   const imageState = useJobImageState();
   const isRemoteOverlay = useIsRemoteOverlay();
   const remoteReadyStates = useReadyPlayers();
   const { clickHandler } = useClickHandler();
-  const { setReadyPlayers } = useOverLayActions();
 
-  const diedPlayers = useDiedPlayer();
   const diedPlayer = diedPlayers.find((diedPlayer) => diedPlayer === trackReference.participant.identity);
-
-  //NOTE - players의 실시간 준비 상태 update
-  const sockets = {
-    setReady: (playerId: string, isReady: boolean) => {
-      setReadyPlayers(playerId, isReady);
-    }
-  };
-
-  useSocketOn(sockets);
-
-  //NOTE - remotePlayer의 Ready 초기 상태
-  socket.on("userInfo", () => {});
 
   if (!trackReference) {
     return null;

--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -3,7 +3,7 @@ import useClickHandler from "@/hooks/useClickHandler";
 import useSocketOn from "@/hooks/useSocketOn";
 import { useDiedPlayer } from "@/store/game-store";
 import { useJobImageState } from "@/store/image-store";
-import { useActivePlayer, useIsRemoteOverlay } from "@/store/overlay-store";
+import { useActivePlayer, useIsRemoteOverlay, useOverLayActions, useReadyPlayers } from "@/store/overlay-store";
 import S from "@/style/livekit/livekit.module.css";
 import { RemoteReadyStates } from "@/types";
 import { ParticipantTile, ParticipantTileProps, useEnsureTrackRef } from "@livekit/components-react";
@@ -16,7 +16,9 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   const imageState = useJobImageState();
   const isRemoteOverlay = useIsRemoteOverlay();
   const { clickHandler } = useClickHandler();
-  const [remoteReadyStates, setRemoteReadyStates] = useState<RemoteReadyStates>({});
+  const remoteReadyStates = useReadyPlayers();
+  const { setReadyPlayers } = useOverLayActions();
+  const [,] = useState<RemoteReadyStates>({});
 
   const diedPlayers = useDiedPlayer();
   const diedPlayer = diedPlayers.find((diedPlayer) => diedPlayer === trackReference.participant.identity);
@@ -24,9 +26,13 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   //NOTE - players의 실시간 준비 상태 update
   const sockets = {
     setReady: (userId: string, isReady: boolean) => {
-      setRemoteReadyStates((prev) => ({ ...prev, [userId]: isReady }));
+      // setRemoteReadyStates((prev) => ({ ...prev, [userId]: isReady }));
+      console.log("너 작동하니?");
+      setReadyPlayers(userId, isReady);
     }
   };
+
+  console.log("remoteReadyStates", remoteReadyStates);
 
   useSocketOn(sockets);
 

--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -29,6 +29,8 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
 
   useSocketOn(sockets);
 
+  //NOTE - remotePlayer의 Ready 초기 상태
+
   if (!trackReference) {
     return null;
   }

--- a/components/mafia/SpeakTimer.tsx
+++ b/components/mafia/SpeakTimer.tsx
@@ -7,7 +7,7 @@ const SpeakTimer = () => {
   const inSelect = useInSelect();
   const [count, setCount] = useState(0);
   const [isCount, setIsCount] = useState(false);
-  const { setInSelect, setIsOverlay, clearActiveImage } = useOverLayActions();
+  const { setInSelect, setIsOverlay, setOverlayReset } = useOverLayActions();
 
   const minutes = Math.floor((count % 3600) / 60);
   const seconds = Math.floor(count % 60);
@@ -22,9 +22,7 @@ const SpeakTimer = () => {
     }
     // 캠 클릭 이벤트 비활성화 및 캠 이미지 초기화
     if (count <= 0 && isCount && inSelect) {
-      setInSelect("");
-      setIsOverlay(false);
-      clearActiveImage();
+      setOverlayReset();
     }
   }, [count]);
 

--- a/components/mafia/SpeakTimer.tsx
+++ b/components/mafia/SpeakTimer.tsx
@@ -7,7 +7,7 @@ const SpeakTimer = () => {
   const inSelect = useInSelect();
   const [count, setCount] = useState(0);
   const [isCount, setIsCount] = useState(false);
-  const { setInSelect, setIsOverlay, clearActiveParticipant } = useOverLayActions();
+  const { setInSelect, setIsOverlay, clearActiveImage } = useOverLayActions();
 
   const minutes = Math.floor((count % 3600) / 60);
   const seconds = Math.floor(count % 60);
@@ -24,7 +24,7 @@ const SpeakTimer = () => {
     if (count <= 0 && isCount && inSelect) {
       setInSelect("");
       setIsOverlay(false);
-      clearActiveParticipant();
+      clearActiveImage();
     }
   }, [count]);
 

--- a/hooks/useMediaSocket.ts
+++ b/hooks/useMediaSocket.ts
@@ -4,10 +4,12 @@ import { useLocalParticipant, useRemoteParticipants } from "@livekit/components-
 import { Track } from "livekit-client";
 import { useEffect, useState } from "react";
 import useSocketOn from "./useSocketOn";
+import { useExitStore } from "@/store/exit-store";
 
 const useMediaSocket = () => {
   const diedPlayerId = useDiedPlayer();
   const [playersMediaStatus, setPlayersMediaStatus] = useState<MediaStatus>();
+  const { setIsExit } = useExitStore();
 
   //NOTE -  로컬 player의 정보
   const localParticipant = useLocalParticipant();
@@ -50,6 +52,13 @@ const useMediaSocket = () => {
       if (localPlayerId == playerId) {
         const localCamera = localParticipant.cameraTrack?.track?.mediaStreamTrack;
         const localMike = localParticipant.microphoneTrack?.track?.mediaStreamTrack;
+
+        //NOTE - 마이크 또는 캠이 없을 시
+        if (!localCamera || !localMike) {
+          console.log("localMike", localMike);
+          console.log("localCamera", localCamera);
+          setIsExit(true);
+        }
 
         localCamera!.enabled = isMedia.camera;
         localMike!.enabled = isMedia.mike;

--- a/hooks/useModalSocket.ts
+++ b/hooks/useModalSocket.ts
@@ -27,7 +27,7 @@ const useModalSocket = () => {
 
     //NOTE - UserRoleModal 모달창 요소
     showAllPlayerRole: (role: Role, timer: number) => {
-      setCurrentModal("userRoleModal");
+      setCurrentModal("UserRoleModal");
       setRole(role);
       setTimer(timer);
       setIsOpen(true);

--- a/store/game-store.ts
+++ b/store/game-store.ts
@@ -8,7 +8,8 @@ const useGameStore = create<GameState>((set) => ({
   actions: {
     setIsReady: (newToggle: boolean) => set({ isReady: newToggle }),
     setIsStart: (newIsStarts: boolean) => set({ isStart: newIsStarts }),
-    setDiedPlayer: (playerId: string) => set((state) => ({ diedPlayerId: [...state.diedPlayerId, playerId] }))
+    setDiedPlayer: (playerId: string) => set((state) => ({ diedPlayerId: [...state.diedPlayerId, playerId] })),
+    setGameReset: () => set({ isReady: false, isStart: false, diedPlayerId: [] })
   }
 }));
 

--- a/store/game-store.ts
+++ b/store/game-store.ts
@@ -2,18 +2,11 @@ import { GameState } from "@/types";
 import { create } from "zustand";
 
 const useGameStore = create<GameState>((set) => ({
-  isReady: false,
-  isStart: false,
   diedPlayerId: [],
   actions: {
-    setIsReady: (newToggle: boolean) => set({ isReady: newToggle }),
-    setIsStart: (newIsStarts: boolean) => set({ isStart: newIsStarts }),
-    setDiedPlayer: (playerId: string) => set((state) => ({ diedPlayerId: [...state.diedPlayerId, playerId] })),
-    setGameReset: () => set({ isReady: false, isStart: false, diedPlayerId: [] })
+    setDiedPlayer: (playerId: string) => set((state) => ({ diedPlayerId: [...state.diedPlayerId, playerId] }))
   }
 }));
 
-export const useIsStart = () => useGameStore((state) => state.isStart);
-export const useIsReady = () => useGameStore((state) => state.isReady);
 export const useDiedPlayer = () => useGameStore((state) => state.diedPlayerId);
 export const useGameActions = () => useGameStore((state) => state.actions);

--- a/store/image-store.ts
+++ b/store/image-store.ts
@@ -5,7 +5,8 @@ import CamCheck from "@/assets/images/cam_check.svg";
 
 const useCamClickImageState = create<ImageState>((set) => ({
   imageState: CamCheck as StaticImageData | null,
-  setImageState: (newImage: StaticImageData | null) => set({ imageState: newImage })
+  setImageState: (newImage: StaticImageData | null) => set({ imageState: newImage }),
+  setImageReset: () => set({ imageState: CamCheck })
 }));
 
 export const useJobImageState = () => useCamClickImageState((state) => state.imageState);

--- a/store/overlay-store.ts
+++ b/store/overlay-store.ts
@@ -15,11 +15,11 @@ const useOverlayStore = create<OverlayState>((set) => ({
     setReadyPlayers: (playerId: string, isReady: boolean) =>
       set((state) => ({ playersReady: { ...state.playersReady, [playerId]: isReady } })),
 
-    //NOTE - 클릭한 user의 정보를 update
+    //NOTE - 클릭한 player의 정보를 update
     setActiveParticipant: (playerId: string | null) => set({ activePlayerId: playerId }),
 
-    //NOTE - 활성화된 user의 정보를 초기화 시킨다.(캠에 보여지는 이미지 비활성화)
-    clearActiveParticipant: () => set({ activePlayerId: null, playersReady: {} }),
+    //NOTE - 활성화된 players의 정보를 초기화 시킨다.(캠에 보여지는 이미지 비활성화)
+    clearActiveImage: () => set({ activePlayerId: null, playersReady: {} }),
 
     //NOTE - 캠 클릭 이벤트 핸들러 및 cursor 활성화 및 비활성화
     setIsOverlay: (newIsOverlay) => set({ isLocalOverlay: newIsOverlay, isRemoteOverlay: newIsOverlay }),

--- a/store/overlay-store.ts
+++ b/store/overlay-store.ts
@@ -18,9 +18,6 @@ const useOverlayStore = create<OverlayState>((set) => ({
     //NOTE - 클릭한 player의 정보를 update
     setActiveParticipant: (playerId: string | null) => set({ activePlayerId: playerId }),
 
-    //NOTE - 활성화된 players의 정보를 초기화 시킨다.(캠에 보여지는 이미지 비활성화)
-    clearActiveImage: () => set({ activePlayerId: null, playersReady: {} }),
-
     //NOTE - 캠 클릭 이벤트 핸들러 및 cursor 활성화 및 비활성화
     setIsOverlay: (newIsOverlay) => set({ isLocalOverlay: newIsOverlay, isRemoteOverlay: newIsOverlay }),
     setIsRemoteOverlay: (newIsOverlay) => set({ isRemoteOverlay: newIsOverlay }),

--- a/store/overlay-store.ts
+++ b/store/overlay-store.ts
@@ -25,7 +25,11 @@ const useOverlayStore = create<OverlayState>((set) => ({
     setIsOverlay: (newIsOverlay) => set({ isLocalOverlay: newIsOverlay, isRemoteOverlay: newIsOverlay }),
     setIsRemoteOverlay: (newIsOverlay) => set({ isRemoteOverlay: newIsOverlay }),
     //NOTE - OO시간 구별(투표, 마피아, 의사, 경찰)
-    setInSelect: (newSelect) => set({ inSelect: newSelect })
+    setInSelect: (newSelect) => set({ inSelect: newSelect }),
+
+    //NOTE - overlay 초기화
+    setOverlayReset: () =>
+      set({ activePlayerId: "", playersReady: {}, isLocalOverlay: false, isRemoteOverlay: false, inSelect: "" })
   }
 }));
 

--- a/store/overlay-store.ts
+++ b/store/overlay-store.ts
@@ -3,6 +3,7 @@ import { OverlayState } from "../types";
 
 const useOverlayStore = create<OverlayState>((set) => ({
   activePlayerId: "",
+  playersReady: {},
   isLocalOverlay: false,
   isRemoteOverlay: false,
   inSelect: "",
@@ -11,11 +12,14 @@ const useOverlayStore = create<OverlayState>((set) => ({
   // activeParticipantIndex: null, //NOTE - 사용처 모름
 
   actions: {
+    setReadyPlayers: (playerId: string, isReady: boolean) =>
+      set((state) => ({ playersReady: { ...state.playersReady, [playerId]: isReady } })),
+
     //NOTE - 클릭한 user의 정보를 update
     setActiveParticipant: (playerId: string | null) => set({ activePlayerId: playerId }),
 
     //NOTE - 활성화된 user의 정보를 초기화 시킨다.(캠에 보여지는 이미지 비활성화)
-    clearActiveParticipant: () => set({ activePlayerId: null }),
+    clearActiveParticipant: () => set({ activePlayerId: null, playersReady: {} }),
 
     //NOTE - 캠 클릭 이벤트 핸들러 및 cursor 활성화 및 비활성화
     setIsOverlay: (newIsOverlay) => set({ isLocalOverlay: newIsOverlay, isRemoteOverlay: newIsOverlay }),
@@ -24,6 +28,9 @@ const useOverlayStore = create<OverlayState>((set) => ({
     setInSelect: (newSelect) => set({ inSelect: newSelect })
   }
 }));
+
+//NOTE - Ready한 player의 캠 위치에 이미지 띄우기
+export const useReadyPlayers = () => useOverlayStore((state) => state.playersReady);
 
 //NOTE -  클릭한 캠 위치에 이미지 띄우기
 export const useActivePlayer = () => useOverlayStore((state) => state.activePlayerId);

--- a/store/show-modal-store.ts
+++ b/store/show-modal-store.ts
@@ -17,7 +17,17 @@ const useShowModalStore = create<ShowModalState>((set) => ({
     setTitle: (newTitle) => set({ title: newTitle }),
     setRole: (newRole) => set({ role: newRole }),
     setVoteResult: (newResult) => set({ voteResult: newResult }),
-    setYesOrNoVoteResult: (newVote) => set({ yesOrNoResult: newVote })
+    setYesOrNoVoteResult: (newVote) => set({ yesOrNoResult: newVote }),
+    setModalReset: () =>
+      set({
+        isOpen: false,
+        currentModal: "",
+        timer: -1,
+        title: "",
+        role: {},
+        voteResult: [],
+        yesOrNoResult: { detail: { noCount: 0, yesCount: 0 }, result: false }
+      })
   }
 }));
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -59,7 +59,6 @@ export interface OverlayState {
 
   actions: {
     setReadyPlayers: (userId: string, isReady: boolean) => void;
-    clearActiveImage: () => void;
     setActiveParticipant: (playerId: string | null) => void;
     setIsOverlay: (newIsOverlay: boolean) => void;
     setIsRemoteOverlay: (newIsOverlay: boolean) => void;
@@ -94,14 +93,9 @@ export interface ImageState {
 }
 
 export interface GameState {
-  isStart: boolean;
-  isReady: boolean;
   diedPlayerId: string[];
   actions: {
-    setIsStart: (isStart: boolean) => void;
-    setIsReady: (isReady: boolean) => void;
     setDiedPlayer: (playerId: string) => void;
-    setGameReset: () => void;
   };
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -59,7 +59,7 @@ export interface OverlayState {
 
   actions: {
     setReadyPlayers: (userId: string, isReady: boolean) => void;
-    clearActiveParticipant: () => void;
+    clearActiveImage: () => void;
     setActiveParticipant: (playerId: string | null) => void;
     setIsOverlay: (newIsOverlay: boolean) => void;
     setIsRemoteOverlay: (newIsOverlay: boolean) => void;

--- a/types/index.ts
+++ b/types/index.ts
@@ -52,11 +52,13 @@ export interface playerMedia {
 
 export interface OverlayState {
   activePlayerId: string | null;
+  playersReady: RemoteReadyStates;
   isLocalOverlay: boolean;
   isRemoteOverlay: boolean;
   inSelect: string;
 
   actions: {
+    setReadyPlayers: (userId: string, isReady: boolean) => void;
     clearActiveParticipant: () => void;
     setActiveParticipant: (playerId: string | null) => void;
     setIsOverlay: (newIsOverlay: boolean) => void;

--- a/types/index.ts
+++ b/types/index.ts
@@ -190,6 +190,11 @@ export interface totalTimeState {
   };
 }
 
+export interface playersInfo {
+  user_id: string;
+  user_nickname: string;
+  is_ready: boolean;
+}
 // export interface TimerState {
 //   timerIds: NodeJS.Timeout[];
 //   setTimerIds: (newTimerId: NodeJS.Timeout) => void;

--- a/types/index.ts
+++ b/types/index.ts
@@ -64,6 +64,7 @@ export interface OverlayState {
     setIsOverlay: (newIsOverlay: boolean) => void;
     setIsRemoteOverlay: (newIsOverlay: boolean) => void;
     setInSelect: (newSelect: string) => void;
+    setOverlayReset: () => void;
   };
 }
 
@@ -89,6 +90,7 @@ export interface OverlayState {
 export interface ImageState {
   imageState: StaticImageData | null;
   setImageState: (newImage: StaticImageData | null) => void;
+  setImageReset: () => void;
 }
 
 export interface GameState {
@@ -99,6 +101,7 @@ export interface GameState {
     setIsStart: (isStart: boolean) => void;
     setIsReady: (isReady: boolean) => void;
     setDiedPlayer: (playerId: string) => void;
+    setGameReset: () => void;
   };
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
  closed #283 

## Task TODOLIST
- [x] 게임 시작 시 게임 시작 버튼 비활성화 및 이미지 초기화
- [x] 방 입장 시 players의 ready 정보를 받아 이미지로 체크
- [x] 테스트한 결과를 바탕으로 Error 처리

## ✨ 개발 내용
```tsx
  useEffect(() => {
    //NOTE - 방 입장 시 한 번만 실행 && Remote Player가 존재할 경우에만 실행
    if (roomId && remotesTrack.length !== 0) {
      socket.emit("usersInfo", roomId);
      console.log("usersInfo socket.emit 실행");
    }
  }, [roomId]);

  const sockets = {
    //NOTE - players의 실시간 준비 상태 update
    setReady: (playerId: string, isReady: boolean) => {
      setReadyPlayers(playerId, isReady);
    },
    //NOTE - players의 Ready 초기 상태
    usersInfo: (players: playersInfo[]) => {
      players.forEach((player) => {
        if (player.is_ready) {
          setReadyPlayers(player.user_id, player.is_ready);
        }
      });
    }
  };
  useSocketOn(sockets);
```
##  ✨ TroubleShotting
### 방 나갈 시에 방 입장 UI가 보이는 현상 발생
#### 구조
```tsx
const RoomPage = () => {
  const { isExit } = useExitStore();

  return <>{isExit ? <Loading /> : <JoinMafiaRoom />}</>;
};
```
- JoinMafiaRoom의 하위 컴포넌트인 MafiaPlayRooms 컴포넌트에서의  방나가기 이벤트 핸들러
```tsx

  //NOTE - 방 나가기 이벤트 헨들러
  const leaveRoom = () => {
    setIsExit(true);
    socket.emit("exitRoom", roomId, userId);
  };

```
```tsx
const Loading = () => {
  const router = useRouter();
  const { setIsExit } = useExitStore();

  useEffect(() => {
    const timer = setTimeout(() => {
      setIsExit(false);
      router.replace("/main");
    }, 3000);

    return () => {
      clearTimeout(timer);
    };
  }, []);

```

현상이 발생하는 이유)  
방을 나갈 시 setIsExit(true); 상태 값이 변경되고 이때 Loading 컴포넌트가 실행 ->  이때 setTimeout이 종료된 후 setIsExit 값을 초기화 시켜주는 로직이 돌아가 JoinMafiaRoom 컴포넌트가 실행되어 방 입장 UI가 보이는 현상이 발생

해결 과정)
- 마피아 페이지에서 방을 나갔을 경우 Loading 컴포넌트가 아닌 페이지를 만들어 Loading 페이지로 이동 시키는 구조를 생각해봤다.
그랬을 경우에는 LoadingPage에서 ``setIsExit(false);`` state 값이 변경되어도 현재 접속한 페이지가 마피아 방 페이지가 아니므로 Error 해결
그러나 단순히, state값의 변화로 인해 Loading 컴포넌트를 Page로 만들기에는 불필요하다고 느꼈으며, 다른 방법을 생각해보았다.

해결) useEffect의 기본 개념인 clean Up 함수를 통해 해결
``` tsx

  useEffect(() => {
    const timer = setTimeout(() => {
      router.replace("/main");
    }, 3000);

// UnMout 시 작동되므로 UI가 표시 되지 않는 걸 확인
    return () => {
      setIsExit(false);
      clearTimeout(timer);
    };
  }, []);

```

