### PR TITLE
[Feat #293] players에게 play 번호 할당

### DIFF
--- a/app/(withGlobalLayout)/main/page.tsx
+++ b/app/(withGlobalLayout)/main/page.tsx
@@ -17,8 +17,11 @@ import RoomSearch from "@/utils/RoomSearch";
 import RoomListItem from "@/components/main/RoomListItem";
 import useGetRoomsSocket from "@/hooks/useGetRoomsSocket";
 import MainSkeleton from "@/components/main/MainSkeleton";
+import { useRouter } from "next/navigation";
 
 const Mainpage = () => {
+  const roomId = useRef("");
+  const router = useRouter();
   const { rooms, setRooms } = useGetRoomsSocket();
   const { isCreate, setIsCreate } = useCreateStore();
   const { userId, nickname, setRoomId, setUserId, setUserNickname } = useConnectStore();
@@ -43,6 +46,14 @@ const Mainpage = () => {
     checkUserInfo();
   }, []);
 
+  useEffect(() => {
+    socket.on("joinRoom", () => {
+      if (roomId.current) {
+        router.push(`/room/${roomId.current}/`);
+      }
+    });
+  }, []);
+
   //NOTE - 로그인 체크, 공통 로직 함수 정의
   const loginErrorHandler = async (emitCallback: () => void) => {
     try {
@@ -64,6 +75,7 @@ const Mainpage = () => {
   //NOTE - 방 리스트 입장하기
   const joinRoomHandler = async (item: Tables<"room_table">) => {
     await loginErrorHandler(() => {
+      roomId.current = item.room_id;
       setRoomId(item.room_id);
       socket.emit("joinRoom", userId, item.room_id, nickname);
     });

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -38,13 +38,15 @@ const LocalParticipant = ({ tracks }: Participants) => {
   const readyHandler = () => {
     const newIsReady = !isReady;
     setIsReady(newIsReady);
-    setGamePlayers(participants); // 게임 시작시 player Number 부여
     socket.emit("setReady", userId, newIsReady);
   };
 
   //NOTE - 게임 시작 이벤트 핸들러
   const startHandler = () => {
     socket.emit("gameStart", roomId, playersCount);
+
+    // 게임 시작시 player Number 부여
+    setGamePlayers(participants);
 
     // 게임 버튼 비활성화
     setIsStartButton(false);
@@ -54,7 +56,7 @@ const LocalParticipant = ({ tracks }: Participants) => {
     setOverlayReset();
   };
 
-  // //NOTE - 게임 시작 시 PlayerNumber를 부여
+  //NOTE - 게임 시작 시 작동
   useEffect(() => {
     const localNumber = gamePlayers.find((player) => localParticipant.name === player.playerName);
 

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -43,6 +43,21 @@ const LocalParticipant = ({ tracks }: Participants) => {
   const startHandler = () => {
     socket.emit("gameStart", roomId, playersCount);
 
+    //NOTE - 닉네임 정렬
+    const gamePlayerName = participants
+      .map((player) => player.name)
+      .sort((a, b) => {
+        if (!a || !b) {
+          return -1;
+        }
+        return a > b ? 1 : -1;
+      });
+
+    //NOTE - PlayerNumber 부여
+    const gamePlayers = gamePlayerName.map((playerName, index) => {
+      return { playerName, PlayerNumber: index + 1 };
+    });
+
     // 게임 버튼 비활성화
     setIsStartButton(false);
 

--- a/components/mafia/LocalParticipant.tsx
+++ b/components/mafia/LocalParticipant.tsx
@@ -1,7 +1,7 @@
 import CamCheck from "@/assets/images/cam_check.svg";
 import PlayerDieImage from "@/assets/images/player_die.svg";
 import useClickHandler from "@/hooks/useClickHandler";
-import { useDiedPlayer } from "@/store/game-store";
+import { useDiedPlayer, useGameActions, useGamePlayers } from "@/store/game-store";
 import { useActivePlayer, useIsLocalOverlay, useOverLayActions } from "@/store/overlay-store";
 import S from "@/style/livekit/livekit.module.css";
 import { Participants } from "@/types";
@@ -20,6 +20,8 @@ const LocalParticipant = ({ tracks }: Participants) => {
   const activePlayerId = useActivePlayer();
   const participants = useParticipants();
   const diedPlayers = useDiedPlayer();
+  const test = useGamePlayers();
+  const { setGamePlayers } = useGameActions();
 
   const [isReady, setIsReady] = useState(false);
   const [isStartButton, setIsStartButton] = useState(true);
@@ -35,28 +37,14 @@ const LocalParticipant = ({ tracks }: Participants) => {
   const readyHandler = () => {
     const newIsReady = !isReady;
     setIsReady(newIsReady);
-
+    setGamePlayers(participants);
     socket.emit("setReady", userId, newIsReady);
   };
 
+  console.log("testest", test);
   //NOTE - 게임 시작 이벤트 핸들러
   const startHandler = () => {
     socket.emit("gameStart", roomId, playersCount);
-
-    //NOTE - 닉네임 정렬
-    const gamePlayerName = participants
-      .map((player) => player.name)
-      .sort((a, b) => {
-        if (!a || !b) {
-          return -1;
-        }
-        return a > b ? 1 : -1;
-      });
-
-    //NOTE - PlayerNumber 부여
-    const gamePlayers = gamePlayerName.map((playerName, index) => {
-      return { playerName, PlayerNumber: index + 1 };
-    });
 
     // 게임 버튼 비활성화
     setIsStartButton(false);

--- a/components/mafia/RemoteParticipant.tsx
+++ b/components/mafia/RemoteParticipant.tsx
@@ -1,11 +1,11 @@
+import useSocketOn from "@/hooks/useSocketOn";
+import { useOverLayActions } from "@/store/overlay-store";
 import S from "@/style/livekit/livekit.module.css";
 import { Participants, playersInfo } from "@/types";
-import { TrackLoop, useLocalParticipant } from "@livekit/components-react";
-import React, { useEffect } from "react";
-import RemoteParticipantTile from "./RemoteParticipantTile";
-import { useOverLayActions } from "@/store/overlay-store";
-import useSocketOn from "@/hooks/useSocketOn";
 import { socket } from "@/utils/socket/socket";
+import { TrackLoop, useLocalParticipant } from "@livekit/components-react";
+import { useEffect } from "react";
+import RemoteParticipantTile from "./RemoteParticipantTile";
 
 const RemoteParticipant = ({ tracks }: Participants) => {
   const { localParticipant } = useLocalParticipant();

--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -1,20 +1,23 @@
 import PlayerDieImages from "@/assets/images/player_die.svg";
 import useClickHandler from "@/hooks/useClickHandler";
-import { useDiedPlayer } from "@/store/game-store";
+import { useDiedPlayer, useGamePlayers } from "@/store/game-store";
 import { useJobImageState } from "@/store/image-store";
 import { useActivePlayer, useIsRemoteOverlay, useReadyPlayers } from "@/store/overlay-store";
 import S from "@/style/livekit/livekit.module.css";
 import { ParticipantTile, ParticipantTileProps, useEnsureTrackRef } from "@livekit/components-react";
 import Image from "next/image";
+import { useEffect, useState } from "react";
 
 const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   const trackReference = useEnsureTrackRef(trackRef);
   const PlayerId = useActivePlayer();
   const diedPlayers = useDiedPlayer();
+  const gamePlayers = useGamePlayers();
   const imageState = useJobImageState();
   const isRemoteOverlay = useIsRemoteOverlay();
   const remoteReadyStates = useReadyPlayers();
   const { clickHandler } = useClickHandler();
+  const [remotePlayerNumber, setRemotePlayerNumber] = useState<number | undefined>();
 
   const diedPlayer = diedPlayers.find((diedPlayer) => diedPlayer === trackReference.participant.identity);
 
@@ -22,12 +25,23 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
     return null;
   }
 
+  //NOTE - 게임 시작 시 PlayerNumber를 부여
+  useEffect(() => {
+    const remoteNumber = gamePlayers.find((player) => trackReference.participant.name === player.playerName);
+
+    if (remoteNumber) {
+      console.log("RemotePlayerNumber", remoteNumber.playerNumber);
+      setRemotePlayerNumber(remoteNumber.playerNumber);
+    }
+  }, [gamePlayers]);
+
   return (
     <>
       <li
         className={`${S.remoteParticipantOverlay} ${PlayerId === trackReference.participant.identity ? S.active : ""}`}
         onClick={isRemoteOverlay ? (e) => clickHandler(e, trackReference.participant.identity) : undefined}
       >
+        {remotePlayerNumber && <p className={"text-red-600"}>{remotePlayerNumber}</p>}
         <ParticipantTile
           disableSpeakingIndicator={true}
           className={`${S.remoteCam} ${isRemoteOverlay ? "cursor-pointer" : ""}`}

--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -25,12 +25,11 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
     return null;
   }
 
-  //NOTE - 게임 시작 시 PlayerNumber를 부여
+  //NOTE - 게임 시작 시 작동
   useEffect(() => {
     const remoteNumber = gamePlayers.find((player) => trackReference.participant.name === player.playerName);
 
     if (remoteNumber) {
-      console.log("RemotePlayerNumber", remoteNumber.playerNumber);
       setRemotePlayerNumber(remoteNumber.playerNumber);
     }
   }, [gamePlayers]);

--- a/store/game-store.ts
+++ b/store/game-store.ts
@@ -7,19 +7,18 @@ const useGameStore = create<GameState>((set) => ({
   actions: {
     setDiedPlayer: (playerId: string) => set((state) => ({ diedPlayerId: [...state.diedPlayerId, playerId] })),
     setGamePlayers: (participants) => {
-      // NOTE - 닉네임 정렬
-      const gamePlayerName = participants
-        .map((player) => player.name)
-        .sort((a, b) => {
-          if (!a || !b) {
-            return -1;
-          }
-          return a > b ? 1 : -1;
-        });
+      // NOTE - 입장 순서로 정렬
+      const gamePlayerName = participants.sort((a, b) => {
+        if (!a.joinedAt || !b.joinedAt) {
+          return 1; // 존재 하지 않을 시 뒤로 이동시킨다.
+        }
+        return new Date(a.joinedAt).getTime() - new Date(b.joinedAt).getTime();
+      });
 
       // NOTE - PlayerNumber 부여
-      const gamePlayers = gamePlayerName.map((playerName, index) => ({
-        playerName,
+      const gamePlayers = gamePlayerName.map((player, index) => ({
+        playerName: player.name,
+        playerJoinAt: player.joinedAt,
         playerNumber: index + 1
       }));
 

--- a/store/game-store.ts
+++ b/store/game-store.ts
@@ -3,10 +3,32 @@ import { create } from "zustand";
 
 const useGameStore = create<GameState>((set) => ({
   diedPlayerId: [],
+  gamePlayersInfo: [],
   actions: {
-    setDiedPlayer: (playerId: string) => set((state) => ({ diedPlayerId: [...state.diedPlayerId, playerId] }))
+    setDiedPlayer: (playerId: string) => set((state) => ({ diedPlayerId: [...state.diedPlayerId, playerId] })),
+    setGamePlayers: (participants) => {
+      // NOTE - 닉네임 정렬
+      const gamePlayerName = participants
+        .map((player) => player.name)
+        .sort((a, b) => {
+          if (!a || !b) {
+            return -1;
+          }
+          return a > b ? 1 : -1;
+        });
+
+      // NOTE - PlayerNumber 부여
+      const gamePlayers = gamePlayerName.map((playerName, index) => ({
+        playerName,
+        playerNumber: index + 1
+      }));
+
+      //NOTE - gamePlayersInfo 저장
+      set({ gamePlayersInfo: gamePlayers });
+    }
   }
 }));
 
+export const useGamePlayers = () => useGameStore((state) => state.gamePlayersInfo);
 export const useDiedPlayer = () => useGameStore((state) => state.diedPlayerId);
 export const useGameActions = () => useGameStore((state) => state.actions);

--- a/store/game-store.ts
+++ b/store/game-store.ts
@@ -10,12 +10,12 @@ const useGameStore = create<GameState>((set) => ({
       // NOTE - 입장 순서로 정렬
       const gamePlayerName = participants.sort((a, b) => {
         if (!a.joinedAt || !b.joinedAt) {
-          return 1; // 존재 하지 않을 시 뒤로 이동시킨다.
+          return 1; // 존재 하지 않을 시 뒤로 이동
         }
         return new Date(a.joinedAt).getTime() - new Date(b.joinedAt).getTime();
       });
 
-      // NOTE - PlayerNumber 부여
+      // NOTE - gamePlayers 요소: playerName, playerJoinAt, playerNumber
       const gamePlayers = gamePlayerName.map((player, index) => ({
         playerName: player.name,
         playerJoinAt: player.joinedAt,

--- a/types/index.ts
+++ b/types/index.ts
@@ -72,6 +72,7 @@ export interface GameState {
 }
 export interface GamePlayerInfo {
   playerName: string | undefined;
+  playerJoinAt: Date | undefined;
   playerNumber: number;
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,6 +2,7 @@ import { TrackReferenceOrPlaceholder } from "@livekit/components-react";
 import { User } from "@supabase/supabase-js";
 import { StaticImageData } from "next/image";
 import { Tables } from "./supabase";
+import { LocalParticipant, RemoteParticipant } from "livekit-client";
 
 export interface MafiaRoom {
   room: string;
@@ -63,9 +64,15 @@ export interface ImageState {
 
 export interface GameState {
   diedPlayerId: string[];
+  gamePlayersInfo: GamePlayerInfo[];
   actions: {
     setDiedPlayer: (playerId: string) => void;
+    setGamePlayers: (participant: (LocalParticipant | RemoteParticipant)[]) => void;
   };
+}
+export interface GamePlayerInfo {
+  playerName: string | undefined;
+  playerNumber: number;
 }
 
 export interface ConnectState {


### PR DESCRIPTION
## 📌 관련 이슈
  closed #293 

## Task TODOLIST
- [x] players에게 play 번호 할당

## ✨ 개발 내용
- 정렬 로직을 zustand 내부에서 처리
- 이유: 정렬한 상태값은 전역 state로 관리해야하며, 컴포넌트 내부에서 아래의 로직을 처리하기에는 가독성이 떨어진다고 판단하여, 컴포넌트 내부에서는 해당 배열의 값만 매개변수로 전달하여  zustand 내부 action에서 처리

```tsx
const gamePlayers = useGamePlayers();
const { setGamePlayers } = useGameActions();
const [localPlayerNumber, setLocalPlayerNumber] = useState<number | undefined>();
...

   setGamePlayers: (participants) => {
      // NOTE 입장 시간으로 정렬
      const gamePlayerName = participants.sort((a, b) => {
        if (!a.joinedAt || !b.joinedAt) {
          return 1; // 존재 하지 않을 시 뒤로 이동
        }
        return new Date(a.joinedAt).getTime() - new Date(b.joinedAt).getTime();
      });

      // NOTE - gamePlayers 요소: playerName, playerJoinAt, playerNumber
      const gamePlayers = gamePlayerName.map((player, index) => ({
        playerName: player.name,
        playerJoinAt: player.joinedAt,
        playerNumber: index + 1
      }));

      //NOTE - gamePlayersInfo 저장
      set({ gamePlayersInfo: gamePlayers });
    }
```

```tsx

 //NOTE - 게임 시작 이벤트 핸들러
  const startHandler = () => {
     ...

    // 게임 시작시 player Number 부여
    setGamePlayers(participants);

  };

  //NOTE -  "gamePlayers" 값이 존재(게임 시작 시) 작동
  useEffect(() => {
    const localNumber = gamePlayers.find((player) => localParticipant.name === player.playerName);

    if (localNumber) {
      setLocalPlayerNumber(localNumber.playerNumber);
    }
  }, [gamePlayers]);


```


##  TroubleShotting
처음 정렬 조건을 닉네임을 기준으로 정렬하였다.
이유는 어느 조건의 정렬이든 상관없이 전체 게임 방 players가 동일하게 정렬만 되면 문제가 없었기 때문이다.

#### 문제 발생
- 게임 시작시 모든 players의 local 환경에 정상적으로 플레이어 번호가 UI에 표시되었지만 번호 순서는 뒤죽박죽으로 표시되는 걸 볼 수 있었다.
- 해결 과정:  게임 시작 시 ``Track( 캠, 오디오)`` 데이터를 앞서 정렬한 순서대로 다시 UI에 보여지게 ``TrackLoop``하였다. 
- 해결한 줄 알았던 부분의 또 다른 문제는 게임 시작시 가장 먼저 실행되어야하는 ``모든 players의 캠 및 오디오 off `` 로직이 정상적으로 작동되지 않는 걸 볼 수 있었다. 
- 로직 순서가 꼬여 ``모든 players의 캠 및 오디오 off `` 할 시기에 다시 ``players의  캠 및 오디오 데이터``의 반복문을 돌려 재실행하기에 문제가 발생하였다.

해결방법
방에 처음 입장 시 LiveKit에서는 ``입장 시간을 기준``으로 자동으로 정렬되기에 캠의 위치를 다시 정렬할 필요없이 입장 시간의 값만 얻을 수 있다면 문제 해결이었다. 그래서 Livekit의 여러 hooks 중 LiveKit에서 제공하는 ``useParticipants`` hooks 요소에서 ``joinAt``이라는 player의 입장 시간을 hooks 요소로 전달해주는 걸 확인

해결: 
> "useParticipants" 훅의 배열 순서는 Local을 기준으로 정렬되기에 시간순으로 다시 정렬해줘야한다.

입장 순으로 정렬 후 번호를 부여하여 캠의 재조정 없이 UI에 표현




