### PR TITLE
[Fix 323] 입장 시간 동일 시) userId로 정렬하여 playerNumber 부여

### DIFF
--- a/components/mafia/RemoteParticipantTile.tsx
+++ b/components/mafia/RemoteParticipantTile.tsx
@@ -6,6 +6,7 @@ import { useActivePlayer, useIsRemoteOverlay, useJobImageState, useReadyPlayers 
 import S from "@/style/livekit/livekit.module.css";
 import { ParticipantTile, ParticipantTileProps, useEnsureTrackRef } from "@livekit/components-react";
 import Image from "next/image";
+import CamCheck from "@/assets/images/cam_check.svg";
 
 const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
   const remote = useEnsureTrackRef(trackRef);
@@ -34,7 +35,7 @@ const RemoteParticipantTile = ({ trackRef }: ParticipantTileProps) => {
         />
         {!diedPlayer ? (
           <div className={`${S.remoteOverlay} ${remoteReadyStates[remote.participant.identity] ? S.active : ""}`}>
-            <Image src={imageState!} alt={remote.participant.identity} />
+            <Image src={imageState || CamCheck} alt={remote.participant.identity} />
           </div>
         ) : (
           <div className={S.playerDieOverlay}>

--- a/hooks/useJoinRoom.ts
+++ b/hooks/useJoinRoom.ts
@@ -23,8 +23,11 @@ const useJoinRoom = () => {
         setLoading(true);
         const userInfo = await checkUserLogIn();
         if (userInfo) {
-          setUserId(userInfo.id);
-          setUserNickname(userInfo.user_metadata.nickname);
+          setUserId(crypto.randomUUID());
+          setUserNickname(crypto.randomUUID());
+
+          // setUserId(userInfo.id);
+          // setUserNickname(userInfo.user_metadata.nickname);
         } else {
           toast.info("로그인 후 입장 가능합니다.");
         }

--- a/hooks/useJoinRoom.ts
+++ b/hooks/useJoinRoom.ts
@@ -23,11 +23,8 @@ const useJoinRoom = () => {
         setLoading(true);
         const userInfo = await checkUserLogIn();
         if (userInfo) {
-          setUserId(crypto.randomUUID());
-          setUserNickname(crypto.randomUUID());
-
-          // setUserId(userInfo.id);
-          // setUserNickname(userInfo.user_metadata.nickname);
+          setUserId(userInfo.id);
+          setUserNickname(userInfo.user_metadata.nickname);
         } else {
           toast.info("로그인 후 입장 가능합니다.");
         }

--- a/utils/mafiaSocket/getPlayerNumber.ts
+++ b/utils/mafiaSocket/getPlayerNumber.ts
@@ -1,11 +1,17 @@
 import { LocalParticipant, RemoteParticipant } from "livekit-client";
 
 const getPlayerNumber = (participants: (LocalParticipant | RemoteParticipant)[]) => {
-  // NOTE - 입장 순서로 정렬
+  // NOTE - 입장  및 id 순서로 정렬
   const gamePlayerName = participants.sort((a, b) => {
+    // 존재 하지 않을 시 제자리
     if (!a.joinedAt || !b.joinedAt) {
-      return 1; // 존재 하지 않을 시 뒤로 이동
+      return 0;
     }
+
+    if (a.joinedAt === b.joinedAt) {
+      return a.identity.localeCompare(b.identity);
+    }
+
     return new Date(a.joinedAt).getTime() - new Date(b.joinedAt).getTime();
   });
 


### PR DESCRIPTION
## 📌 관련 이슈

  closed #323 

## Task TODOLIST
- [x] 입장 순서 동일 시 userId(문자열) 기준으로 정렬

## ✨ 개발 내용
입장 시간 동일 시 닉네임이 아닌 userId로 정렬하여 playerNumber값을 부여한다.
닉네임 또한 중복이될 수 있기에 유니크한 값인 userId로 기준을 잡았다.

```tsx
import { LocalParticipant, RemoteParticipant } from "livekit-client";

const getPlayerNumber = (participants: (LocalParticipant | RemoteParticipant)[]) => {
  // NOTE - 입장  및 id 순서로 정렬
  const gamePlayerName = participants.sort((a, b) => {
    // 존재 하지 않을 시 제자리
    if (!a.joinedAt || !b.joinedAt) {
      return 0;
    }

    if (a.joinedAt === b.joinedAt) {
      return a.identity.localeCompare(b.identity);
    }

    return new Date(a.joinedAt).getTime() - new Date(b.joinedAt).getTime();
  });

  // NOTE - gamePlayers: {playerName, playerJoinAt, playerNumber}
  const gamePlayers = gamePlayerName.map((player, index) => ({
    playerId: player.identity,
    playerName: player.name,
    playerJoinAt: player.joinedAt,
    number: index + 1
  }));

  return gamePlayers;
};

export default getPlayerNumber;

```
##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
```
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
https://hianna.tistory.com/409
